### PR TITLE
ETAPE 2 - Auth JWT dev + endpoints proteges + tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,9 @@ JWT_ALGO=HS256
 JWT_TTL_SECONDS=3600
 CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 
+# Dev user (pour ETAPE 2 uniquement)
+DEV_USER=admin
+DEV_PASSWORD=admin123
+
 # DB (placeholder pour etapes suivantes)
 DB_DSN=sqlite:///./cc.db

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           ruff backend
           mypy backend
       - name: Tests
+        env:
+          DEV_USER: admin
+          DEV_PASSWORD: admin123
         run: |
           pytest -q --cov=backend
   compose_smoke:
@@ -30,6 +33,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build and run compose
+        env:
+          DEV_USER: admin
+          DEV_PASSWORD: admin123
         run: |
           docker compose up -d --build
           sleep 5

--- a/PS1/smoke_auth.ps1
+++ b/PS1/smoke_auth.ps1
@@ -1,0 +1,28 @@
+$ErrorActionPreference = "Stop"
+$Base = "http://localhost:8001"
+$User = $env:DEV_USER; if (-not $User) { $User = "admin" }
+$Pass = $env:DEV_PASSWORD; if (-not $Pass) { $Pass = "admin123" }
+
+Write-Host "== HEALTH ==" -ForegroundColor Cyan
+$h = Invoke-RestMethod -Method GET -Uri "$Base/healthz" -TimeoutSec 5
+"Health: $($h.status) v$($h.version)"
+
+Write-Host "== LOGIN ==" -ForegroundColor Cyan
+try {
+    $t = Invoke-RestMethod -Method POST -Uri "$Base/auth/token" `
+        -ContentType "application/json" -Body (@{username=$User; password=$Pass} | ConvertTo-Json)
+    $TOKEN = $t.access_token
+    if (-not $TOKEN) { throw "Pas de token" }
+    Write-Host "Token OK (taille=$($TOKEN.Length))" -ForegroundColor Green
+} catch {
+    Write-Error "Echec login (401 attendu si mauvais mots de passe)"
+    exit 1
+}
+
+Write-Host "== /auth/me ==" -ForegroundColor Cyan
+$r = Invoke-RestMethod -Method GET -Uri "$Base/auth/me" -Headers @{Authorization="Bearer $TOKEN"}
+"User: $($r.username)"
+
+Write-Host "== /debug/secret ==" -ForegroundColor Cyan
+$r2 = Invoke-RestMethod -Method GET -Uri "$Base/debug/secret" -Headers @{Authorization="Bearer $TOKEN"}
+"Secret: $($r2.secret)"

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,19 +1,18 @@
-# Coulisses Crew API (ETAPE 1)
+# Coulisses Crew API (ETAPE 2)
 
-Windows-first. Voir dossiers PS1/ pour scripts.
-
-## Local (sans Docker)
-
-* PS1/setup.ps1 : cree venv, installe deps
-* PS1/run.ps1 : lance l API
-* PS1/test.ps1 : tests unitaires + HTTP
-* PS1/lint.ps1 : ruff + mypy
-
-## Docker
-
-* PS1/compose_up.ps1 / compose_down.ps1
+Auth JWT minimale de dev (NE PAS UTILISER EN PROD telle quelle).
 
 ## Endpoints
 
 * GET /healthz
+* POST /auth/token {username,password}
+* GET /auth/me (Bearer)
+* GET /debug/secret (Bearer)
 * POST /echo
+
+## Flux dev rapide
+
+1. Copier .env.example en .env et ajuster DEV_USER/DEV_PASSWORD
+2. PS1\setup.ps1
+3. PS1\run.ps1
+4. PS1\smoke_auth.ps1 (teste token + routes protegees)

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from .deps import pagination_params
+from .deps import get_current_user, pagination_params
 
 router = APIRouter()
 
@@ -15,7 +15,7 @@ class HealthModel(BaseModel):
 
 @router.get("/healthz", response_model=HealthModel, tags=["health"])
 def healthz() -> HealthModel:
-    return HealthModel(status="ok", version="0.1.0")
+    return HealthModel(status="ok", version="0.2.0")
 
 
 class EchoIn(BaseModel):
@@ -30,5 +30,22 @@ class EchoOut(BaseModel):
 
 @router.post("/echo", response_model=EchoOut, tags=["debug"])
 def echo(payload: EchoIn, pg: dict[str, int] = Depends(pagination_params)) -> EchoOut:  # noqa: B008
-    # Exemple de logs cote serveur: on laisse a main.py
     return EchoOut(message=payload.message, page=pg["page"], page_size=pg["page_size"])
+
+
+class MeOut(BaseModel):
+    username: str
+
+
+@router.get("/auth/me", response_model=MeOut, tags=["auth"])
+def me(current: dict[str, str] = Depends(get_current_user)) -> MeOut:  # noqa: B008
+    return MeOut(username=current["username"])
+
+
+class SecretOut(BaseModel):
+    secret: str
+
+
+@router.get("/debug/secret", response_model=SecretOut, tags=["debug"])
+def secret(current: dict[str, str] = Depends(get_current_user)) -> SecretOut:  # noqa: B008
+    return SecretOut(secret=f"Bonjour {current['username']}, zone protegee.")

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel
+
+from .config import settings
+from .security import create_access_token
+
+router = APIRouter()
+
+
+class TokenOut(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class LoginIn(BaseModel):
+    username: str
+    password: str
+
+
+@router.post("/auth/token", response_model=TokenOut, tags=["auth"])
+def login(form: LoginIn) -> TokenOut:
+    if form.username != settings.DEV_USER or form.password != settings.DEV_PASSWORD:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Identifiants invalides",
+        )
+    token = create_access_token(sub=form.username)
+    return TokenOut(access_token=token)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -22,6 +22,9 @@ class Settings:
     JWT_TTL_SECONDS: int = int(os.getenv("JWT_TTL_SECONDS", "3600"))
     CORS_ORIGINS: list[str] = _split_csv(os.getenv("CORS_ORIGINS", ""))
 
+    DEV_USER: str = os.getenv("DEV_USER", "admin")
+    DEV_PASSWORD: str = os.getenv("DEV_PASSWORD", "admin123")
+
     DB_DSN: str = os.getenv("DB_DSN", "sqlite:///./cc.db")
 
 

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from fastapi import Query
+from fastapi import Header, HTTPException, Query, status
 
 from .config import settings
+from .security import decode_access_token
 
 
 def pagination_params(
@@ -15,3 +16,11 @@ def pagination_params(
     ),
 ):
     return {"page": page, "page_size": page_size}
+
+
+def get_current_user(authorization: str | None = Header(default=None)) -> dict[str, str]:
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token manquant")
+    token = authorization.split(" ", 1)[1]
+    data = decode_access_token(token)
+    return {"username": data.sub}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,8 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import JSONResponse
 
-from .api import router
+from .api import router as api_router
+from .auth import router as auth_router
 from .config import settings
 
 
@@ -33,8 +34,7 @@ def create_app() -> FastAPI:
         )
 
     @app.middleware("http")
-    async def timeout_and_logging(request: Request, call_next):
-        # Logs FR et simple controle de timeout cote client (recommande httpx cote client)
+    async def logging_mw(request: Request, call_next):
         logging.info("Requete %s %s", request.method, request.url.path)
         response = await call_next(request)
         return response
@@ -44,7 +44,8 @@ def create_app() -> FastAPI:
         logging.exception("Erreur serveur: %s", exc)
         return JSONResponse({"detail": "Erreur interne serveur"}, status_code=500)
 
-    app.include_router(router)
+    app.include_router(auth_router)
+    app.include_router(api_router)
     return app
 
 

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from fastapi import HTTPException, status
+from pydantic import BaseModel
+
+from .config import settings
+
+
+class TokenData(BaseModel):
+    sub: str
+    exp: int
+
+
+def create_access_token(sub: str) -> str:
+    expire = datetime.now(tz=UTC) + timedelta(seconds=settings.JWT_TTL_SECONDS)
+    payload = {"sub": sub, "exp": int(expire.timestamp())}
+    token = jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGO)
+    return token
+
+
+def decode_access_token(token: str) -> TokenData:
+    try:
+        payload = jwt.decode(token, settings.JWT_SECRET, algorithms=[settings.JWT_ALGO])
+        return TokenData(sub=str(payload.get("sub")), exp=int(payload.get("exp")))
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token expire",
+        ) from None
+    except jwt.InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token invalide",
+        ) from None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,13 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coulisses-crew-api"
-version = "0.1.0"
+version = "0.2.0"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi==0.115.0",
     "uvicorn[standard]==0.30.6",
     "pydantic==2.8.2",
     "httpx==0.27.0",
+    "pyjwt==2.9.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,40 @@
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.main import app
+
+client = TestClient(app)
+
+
+def _get_token(username: str, password: str) -> str | None:
+    r = client.post("/auth/token", json={"username": username, "password": password})
+    if r.status_code == 200:
+        return r.json()["access_token"]
+    return None
+
+
+def test_login_ok_and_me() -> None:
+    token = _get_token(settings.DEV_USER, settings.DEV_PASSWORD)
+    assert token is not None
+    r = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+    assert r.json()["username"] == settings.DEV_USER
+
+
+def test_login_ko_bad_password() -> None:
+    r = client.post("/auth/token", json={"username": settings.DEV_USER, "password": "bad"})
+    assert r.status_code == 401
+
+
+def test_me_unauthorized_no_token() -> None:
+    r = client.get("/auth/me")
+    assert r.status_code == 401
+
+
+def test_secret_ok_and_ko() -> None:
+    token = _get_token(settings.DEV_USER, settings.DEV_PASSWORD)
+    assert token
+    r_ok = client.get("/debug/secret", headers={"Authorization": f"Bearer {token}"})
+    assert r_ok.status_code == 200
+    r_ko = client.get("/debug/secret", headers={"Authorization": "Bearer invalid"})
+    assert r_ko.status_code == 401


### PR DESCRIPTION
## Summary
- add minimal JWT auth with token issuance and protected endpoints
- expose `POST /auth/token`, `GET /auth/me`, `GET /debug/secret`
- add tests and smoke script for auth flows

## Testing
- `ruff check backend`
- `mypy backend`
- `pytest -q --cov=backend`


------
https://chatgpt.com/codex/tasks/task_e_68a5afcb78888330b36ae35335db7ba1