### PR TITLE
Fix CI Ruff check + .env auto-generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Application
+APP_NAME=Coulisses Crew API
+APP_ENV=dev
+APP_HOST=0.0.0.0
+APP_PORT=8001
+APP_LOG_LEVEL=info
+APP_DEFAULT_PAGE_SIZE=50
+APP_MAX_PAGE_SIZE=200
+APP_REQUEST_TIMEOUT_SECONDS=15
+
+# Security (NE PAS UTILISER EN PROD)
+JWT_SECRET=changeme-dev
+JWT_ALGO=HS256
+JWT_TTL_SECONDS=3600
+CORS_ORIGINS=http://localhost:3000,http://localhost:5173
+
+# DB (placeholder pour etapes suivantes)
+DB_DSN=sqlite:///./cc.db

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,107 @@
+name: CI
+on:
+  push:
+  pull_request:
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          pip install -e backend[dev]
+      - name: Create .env (defaults for CI)
+        run: |
+          echo "APP_ENV=ci" >> .env
+          echo "APP_LOG_LEVEL=info" >> .env
+          echo "DEV_USER=${DEV_USER:-admin}" >> .env
+          echo "DEV_PASSWORD=${DEV_PASSWORD:-admin123}" >> .env
+          echo "JWT_SECRET=ci-secret" >> .env
+          echo "JWT_ALGO=HS256" >> .env
+          echo "JWT_TTL_SECONDS=3600" >> .env
+          echo "CORS_ORIGINS=[http://localhost:3000,http://localhost:5173]" >> .env
+          echo "DB_DSN=sqlite:///./cc.db" >> .env
+      - name: Lint
+        run: |
+          ruff check backend
+          mypy backend
+      - name: Tests
+        env:
+          DEV_USER: admin
+          DEV_PASSWORD: admin123
+        run: |
+          pytest -q --cov=backend
+  windows_smoke:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install (venv)
+        shell: pwsh
+        run: |
+          python -m pip install -U pip
+          pip install -e backend[dev]
+      - name: Create .env (defaults for CI)
+        shell: pwsh
+        run: |
+          @"
+APP_ENV=ci
+APP_LOG_LEVEL=info
+DEV_USER=$($env:DEV_USER -ne $null ? $env:DEV_USER : "admin")
+DEV_PASSWORD=$($env:DEV_PASSWORD -ne $null ? $env:DEV_PASSWORD : "admin123")
+JWT_SECRET=ci-secret
+JWT_ALGO=HS256
+JWT_TTL_SECONDS=3600
+CORS_ORIGINS=http://localhost:3000,http://localhost:5173
+DB_DSN=sqlite:///./cc.db
+"@ | Out-File -FilePath .env -Encoding ascii
+      - name: Start API (bg)
+        shell: pwsh
+        run: |
+          ./PS1/run_bg.ps1
+      - name: Smoke auth (PowerShell)
+        shell: pwsh
+        env:
+          DEV_USER: admin
+          DEV_PASSWORD: admin123
+        run: |
+          ./PS1/smoke_auth.ps1
+  compose_smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create .env (defaults for CI)
+        run: |
+          echo "APP_ENV=ci" >> .env
+          echo "APP_LOG_LEVEL=info" >> .env
+          echo "DEV_USER=${DEV_USER:-admin}" >> .env
+          echo "DEV_PASSWORD=${DEV_PASSWORD:-admin123}" >> .env
+          echo "JWT_SECRET=ci-secret" >> .env
+          echo "JWT_ALGO=HS256" >> .env
+          echo "JWT_TTL_SECONDS=3600" >> .env
+          echo "CORS_ORIGINS=[http://localhost:3000,http://localhost:5173]" >> .env
+          echo "DB_DSN=sqlite:///./cc.db" >> .env
+      - name: Build and run compose (skip if docker unavailable)
+        run: |
+          if ! command -v docker >/dev/null 2>&1; then
+            echo "Docker non disponible sur ce runner, on saute ce job."
+            exit 0
+          fi
+          docker compose up -d --build
+          sleep 5
+          code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8001/healthz)
+          echo "HTTP=$code"
+          test "$code" = "200"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Python
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.sqlite3
+*.egg-info/
+.venv/
+.env
+.coverage
+htmlcov/
+.pytest_cache/
+.mypy_cache/
+
+# VSCode
+.vscode/
+
+# Docker
+*.log
+dist/
+build/

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+
+COPY backend/pyproject.toml /app/backend/pyproject.toml
+RUN pip install --no-cache-dir -U pip && \
+    pip install --no-cache-dir -e /app/backend[dev]
+
+COPY backend /app/backend
+
+EXPOSE 8001
+CMD ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001", "--workers", "2"]

--- a/PS1/compose_down.ps1
+++ b/PS1/compose_down.ps1
@@ -1,0 +1,2 @@
+$ErrorActionPreference = "Stop"
+docker compose down

--- a/PS1/compose_up.ps1
+++ b/PS1/compose_up.ps1
@@ -1,0 +1,3 @@
+$ErrorActionPreference = "Stop"
+docker compose up -d --build
+Write-Host "API dispo: http://localhost:8001/healthz" -ForegroundColor Green

--- a/PS1/lint.ps1
+++ b/PS1/lint.ps1
@@ -1,0 +1,3 @@
+$ErrorActionPreference = "Stop"
+..venv\Scripts\python.exe -m ruff check backend
+..venv\Scripts\python.exe -m mypy backend

--- a/PS1/run.ps1
+++ b/PS1/run.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = "Stop"
+if (-not (Test-Path .\.venv\Scripts\python.exe)) {
+    Write-Error "Environnement non initialise. Lancez PS1\setup.ps1" ; exit 1
+}
+$env:APP_ENV = "dev"
+$env:APP_LOG_LEVEL = "info"
+Write-Host "Lancement API sur http://localhost:8001 ..." -ForegroundColor Cyan
+.\.venv\Scripts\python.exe -m uvicorn app.main:app --app-dir backend --host 0.0.0.0 --port 8001

--- a/PS1/run_bg.ps1
+++ b/PS1/run_bg.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = "Stop"
+if (-not (Test-Path ..venv\Scripts\python.exe)) {
+    Write-Error "Environnement non initialise. Lancez PS1\setup.ps1" ; exit 1
+}
+Start-Process "..venv\Scripts\python.exe" -ArgumentList "-m uvicorn app.main:app --app-dir backend --host 0.0.0.0 --port 8001" `
+    -NoNewWindow
+Start-Sleep -Seconds 2
+Write-Host "API demarree en arriere-plan sur http://localhost:8001" -ForegroundColor Green

--- a/PS1/setup.ps1
+++ b/PS1/setup.ps1
@@ -1,0 +1,9 @@
+Param(
+    [string]$PythonExe = "python"
+)
+$ErrorActionPreference = "Stop"
+Write-Host "Creation venv..." -ForegroundColor Cyan
+& $PythonExe -m venv .venv
+.\.venv\Scripts\pip.exe install -U pip
+.\.venv\Scripts\pip.exe install -e backend[dev]
+Write-Host "OK: environnement pret." -ForegroundColor Green

--- a/PS1/smoke_auth.ps1
+++ b/PS1/smoke_auth.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = "Stop"
+try {
+    $resp = Invoke-WebRequest -UseBasicParsing http://localhost:8001/healthz -TimeoutSec 5
+    if ($resp.StatusCode -ne 200) { throw "HTTP $($resp.StatusCode)" }
+    Write-Host "OK /healthz 200" -ForegroundColor Green
+} catch {
+    Write-Error "Smoke test failed: $_"
+    exit 1
+}

--- a/PS1/test.ps1
+++ b/PS1/test.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = "Stop"
+if (-not (Test-Path ..venv\Scripts\pytest.exe)) {
+    Write-Error "Tests non disponibles. Lancez PS1\setup.ps1" ; exit 1
+}
+Write-Host "== Lints ==" -ForegroundColor Cyan
+..venv\Scripts\python.exe -m ruff check backend
+..venv\Scripts\python.exe -m mypy backend
+Write-Host "== Unit tests ==" -ForegroundColor Cyan
+..venv\Scripts\pytest.exe -q --cov=backend --cov-report=term-missing

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,19 @@
+# Coulisses Crew API (ETAPE 1)
+
+Windows-first. Voir dossiers PS1/ pour scripts.
+
+## Local (sans Docker)
+
+* PS1/setup.ps1 : cree venv, installe deps
+* PS1/run.ps1 : lance l API
+* PS1/test.ps1 : tests unitaires + HTTP
+* PS1/lint.ps1 : ruff + mypy
+
+## Docker
+
+* PS1/compose_up.ps1 / compose_down.ps1
+
+## Endpoints
+
+* GET /healthz
+* POST /echo

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["create_app"]

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from .deps import pagination_params
+
+router = APIRouter()
+
+
+class HealthModel(BaseModel):
+    status: str
+    version: str
+
+
+@router.get("/healthz", response_model=HealthModel, tags=["health"])
+def healthz() -> HealthModel:
+    return HealthModel(status="ok", version="0.1.0")
+
+
+class EchoIn(BaseModel):
+    message: str
+
+
+class EchoOut(BaseModel):
+    message: str
+    page: int
+    page_size: int
+
+
+@router.post("/echo", response_model=EchoOut, tags=["debug"])
+def echo(payload: EchoIn, pg: dict[str, int] = Depends(pagination_params)) -> EchoOut:  # noqa: B008
+    # Exemple de logs cote serveur: on laisse a main.py
+    return EchoOut(message=payload.message, page=pg["page"], page_size=pg["page_size"])

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+
+
+def _split_csv(value: str) -> list[str]:
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+class Settings:
+    APP_NAME: str = os.getenv("APP_NAME", "Coulisses Crew API")
+    APP_ENV: str = os.getenv("APP_ENV", "dev")
+    APP_HOST: str = os.getenv("APP_HOST", "0.0.0.0")
+    APP_PORT: int = int(os.getenv("APP_PORT", "8001"))
+    APP_LOG_LEVEL: str = os.getenv("APP_LOG_LEVEL", "info")
+    APP_DEFAULT_PAGE_SIZE: int = int(os.getenv("APP_DEFAULT_PAGE_SIZE", "50"))
+    APP_MAX_PAGE_SIZE: int = int(os.getenv("APP_MAX_PAGE_SIZE", "200"))
+    APP_REQUEST_TIMEOUT_SECONDS: int = int(os.getenv("APP_REQUEST_TIMEOUT_SECONDS", "15"))
+
+    JWT_SECRET: str = os.getenv("JWT_SECRET", "changeme-dev")
+    JWT_ALGO: str = os.getenv("JWT_ALGO", "HS256")
+    JWT_TTL_SECONDS: int = int(os.getenv("JWT_TTL_SECONDS", "3600"))
+    CORS_ORIGINS: list[str] = _split_csv(os.getenv("CORS_ORIGINS", ""))
+
+    DB_DSN: str = os.getenv("DB_DSN", "sqlite:///./cc.db")
+
+
+settings = Settings()

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from fastapi import Query
+
+from .config import settings
+
+
+def pagination_params(
+    page: int = Query(1, ge=1, description="Numero de page (>=1)"),
+    page_size: int = Query(
+        default=settings.APP_DEFAULT_PAGE_SIZE,
+        ge=1,
+        le=settings.APP_MAX_PAGE_SIZE,
+        description="Taille de page",
+    ),
+):
+    return {"page": page, "page_size": page_size}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+from logging import Formatter, StreamHandler
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.responses import JSONResponse
+
+from .api import router
+from .config import settings
+
+
+def _setup_logging() -> None:
+    level = getattr(logging, settings.APP_LOG_LEVEL.upper(), logging.INFO)
+    logging.basicConfig(level=level)
+    handler = StreamHandler()
+    handler.setFormatter(Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+    root = logging.getLogger()
+    root.handlers = [handler]
+
+
+def create_app() -> FastAPI:
+    _setup_logging()
+    app = FastAPI(title=settings.APP_NAME)
+    if settings.CORS_ORIGINS:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=settings.CORS_ORIGINS,
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+    @app.middleware("http")
+    async def timeout_and_logging(request: Request, call_next):
+        # Logs FR et simple controle de timeout cote client (recommande httpx cote client)
+        logging.info("Requete %s %s", request.method, request.url.path)
+        response = await call_next(request)
+        return response
+
+    @app.exception_handler(Exception)
+    async def on_error(request: Request, exc: Exception):
+        logging.exception("Erreur serveur: %s", exc)
+        return JSONResponse({"detail": "Erreur interne serveur"}, status_code=500)
+
+    app.include_router(router)
+    return app
+
+
+app = create_app()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "coulisses-crew-api"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi==0.115.0",
+    "uvicorn[standard]==0.30.6",
+    "pydantic==2.8.2",
+    "httpx==0.27.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest==8.3.2",
+    "pytest-cov==5.0.0",
+    "ruff==0.6.8",
+    "mypy==1.11.2",
+    "types-requests",
+    "requests==2.32.3",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+select = ["E", "F", "W", "I", "UP", "B"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = false
+warn_unused_ignores = true
+warn_redundant_casts = true
+disallow_untyped_defs = false

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health_ok() -> None:
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+
+def test_unknown_path_404() -> None:
+    r = client.get("/does-not-exist")
+    assert r.status_code == 404

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    env_file:
+      - .env
+    ports:
+      - "8001:8001"
+    restart: unless-stopped

--- a/scripts/bash/run.sh
+++ b/scripts/bash/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. .venv/bin/activate
+uvicorn app.main:app --app-dir backend --host 0.0.0.0 --port 8001

--- a/scripts/bash/setup.sh
+++ b/scripts/bash/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python -m venv .venv
+. .venv/bin/activate
+pip install -U pip
+pip install -e backend[dev]

--- a/scripts/bash/test.sh
+++ b/scripts/bash/test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. .venv/bin/activate
+ruff check backend
+mypy backend
+pytest -q --cov=backend


### PR DESCRIPTION
## Summary
- replace deprecated `ruff` invocations with `ruff check` across local scripts
- generate `.env` with safe defaults in CI and add Windows smoke helpers

## Testing
- `ruff check backend`
- `mypy backend`
- `pytest -q --cov=backend`
- `( if ! command -v docker >/dev/null 2>&1; then echo "Docker non disponible sur ce runner, on saute ce job."; exit 0; fi; docker compose up -d --build; sleep 5; code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8001/healthz); echo "HTTP=$code"; test "$code" = "200" )`


------
https://chatgpt.com/codex/tasks/task_e_68a5addd781c833084c9fe5fe856daae