### PR TITLE
Fix CI Windows - scripts PS1 presents + init venv avant smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,11 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
-      - name: Python deps (venv inline)
-        shell: pwsh
-        run: |
-          python -m pip install -U pip
-          pip install -e backend[dev]
-      - name: Assert files present
+      - name: Assert scripts present
         shell: pwsh
         run: |
           Get-ChildItem -Recurse PS1 | Out-String | Write-Host
+          if (-not (Test-Path "PS1/setup.ps1")) { Write-Error "PS1/setup.ps1 manquant" ; exit 1 }
           if (-not (Test-Path "PS1/run_bg.ps1")) { Write-Error "PS1/run_bg.ps1 manquant" ; exit 1 }
           if (-not (Test-Path "PS1/smoke_auth.ps1")) { Write-Error "PS1/smoke_auth.ps1 manquant" ; exit 1 }
       - name: Create .env (defaults for CI)
@@ -73,8 +69,12 @@ jobs:
           JWT_ALGO=HS256
           JWT_TTL_SECONDS=3600
           CORS_ORIGINS=http://localhost:3000,http://localhost:5173
+          
           DB_DSN=sqlite:///./cc.db
           "@ | Out-File -FilePath .env -Encoding ascii
+      - name: Initialize environment (venv + deps)
+        shell: pwsh
+        run: ./PS1/setup.ps1
       - name: Start API (bg)
         shell: pwsh
         run: ./PS1/run_bg.ps1

--- a/PS1/run_bg.ps1
+++ b/PS1/run_bg.ps1
@@ -1,31 +1,19 @@
-Param(
-    [int]$Port = 8001
-)
+Param([int]$Port = 8001)
 $ErrorActionPreference = "Stop"
 
-# Verif venv
 if (-not (Test-Path .\.venv\Scripts\python.exe)) {
     Write-Error "Environnement non initialise. Lancez PS1\setup.ps1" ; exit 1
 }
-
-# Dossier app
 if (-not (Test-Path .\backend\app\main.py)) {
     Write-Error "Fichier backend\app\main.py introuvable. Lancez depuis la racine du repo." ; exit 1
 }
-
-# Variables d env minimales
 if (-not (Test-Path .env)) {
     Write-Host "Avertissement: .env absent. Copie .env.example -> .env" -ForegroundColor Yellow
     if (Test-Path .env.example) { Copy-Item .env.example .env }
 }
 
 Write-Host "Lancement API en arriere-plan sur http://localhost:$Port ..." -ForegroundColor Cyan
-$Args = @(
-    "-m","uvicorn","app.main:app",
-    "--app-dir","backend",
-    "--host","0.0.0.0",
-    "--port",$Port
-)
+$Args = @("-m","uvicorn","app.main:app","--app-dir","backend","--host","0.0.0.0","--port",$Port)
 Start-Process -WindowStyle Hidden -FilePath .\.venv\Scripts\python.exe -ArgumentList $Args -PassThru | Out-Null
 Start-Sleep -Seconds 5
 try {
@@ -33,10 +21,9 @@ try {
     if ($code -eq 200) {
         Write-Host "Backend demarre (bg), /healthz 200." -ForegroundColor Green
     } else {
-        Write-Error "Backend lance mais /healthz renvoie $code"
-        exit 1
+        Write-Error "Backend lance mais /healthz = $code" ; exit 1
     }
 } catch {
-    Write-Error "Echec de ping /healthz: $($_.Exception.Message)"
-    exit 1
+    Write-Error "Echec ping /healthz: $($_.Exception.Message)" ; exit 1
 }
+

--- a/PS1/setup.ps1
+++ b/PS1/setup.ps1
@@ -4,6 +4,9 @@ Param(
 $ErrorActionPreference = "Stop"
 Write-Host "Creation venv..." -ForegroundColor Cyan
 & $PythonExe -m venv .venv
+if ($LASTEXITCODE -ne 0) { Write-Error "Echec creation venv" ; exit 1 }
 .\.venv\Scripts\pip.exe install -U pip
+if ($LASTEXITCODE -ne 0) { Write-Error "Echec upgrade pip" ; exit 1 }
 .\.venv\Scripts\pip.exe install -e backend[dev]
+if ($LASTEXITCODE -ne 0) { Write-Error "Echec installation deps" ; exit 1 }
 Write-Host "OK: environnement pret." -ForegroundColor Green

--- a/PS1/smoke_auth.ps1
+++ b/PS1/smoke_auth.ps1
@@ -4,25 +4,21 @@ $User = $env:DEV_USER; if (-not $User) { $User = "admin" }
 $Pass = $env:DEV_PASSWORD; if (-not $Pass) { $Pass = "admin123" }
 
 Write-Host "== HEALTH ==" -ForegroundColor Cyan
-$h = Invoke-RestMethod -Method GET -Uri "$Base/healthz" -TimeoutSec 5
+$h = Invoke-RestMethod -Method GET -Uri "$Base/healthz" -TimeoutSec 10
 "Health: $($h.status) v$($h.version)"
 
 Write-Host "== LOGIN ==" -ForegroundColor Cyan
-try {
-    $t = Invoke-RestMethod -Method POST -Uri "$Base/auth/token" `
-        -ContentType "application/json" -Body (@{username=$User; password=$Pass} | ConvertTo-Json)
-    $TOKEN = $t.access_token
-    if (-not $TOKEN) { throw "Pas de token" }
-    Write-Host "Token OK (taille=$($TOKEN.Length))" -ForegroundColor Green
-} catch {
-    Write-Error "Echec login (401 attendu si mauvais mots de passe)"
-    exit 1
-}
+$t = Invoke-RestMethod -Method POST -Uri "$Base/auth/token" -ContentType "application/json" -Body (@{username=$User; password=$Pass} | ConvertTo-Json)
+$TOKEN = $t.access_token
+if (-not $TOKEN) { throw "Pas de token recu" }
+Write-Host "Token OK (len=$($TOKEN.Length))" -ForegroundColor Green
 
 Write-Host "== /auth/me ==" -ForegroundColor Cyan
-$r = Invoke-RestMethod -Method GET -Uri "$Base/auth/me" -Headers @{Authorization="Bearer $TOKEN"}
+$r = Invoke-RestMethod -Method GET -Uri "$Base/auth/me" -Headers @{Authorization="Bearer $TOKEN"} -TimeoutSec 10
 "User: $($r.username)"
 
 Write-Host "== /debug/secret ==" -ForegroundColor Cyan
-$r2 = Invoke-RestMethod -Method GET -Uri "$Base/debug/secret" -Headers @{Authorization="Bearer $TOKEN"}
+$r2 = Invoke-RestMethod -Method GET -Uri "$Base/debug/secret" -Headers @{Authorization="Bearer $TOKEN"} -TimeoutSec 10
 "Secret: $($r2.secret)"
+Write-Host "Smoke auth OK" -ForegroundColor Green
+


### PR DESCRIPTION
## Summary
- add missing checks in PowerShell setup and smoke scripts
- ensure Windows smoke job initializes venv before starting API

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5ef4e7e80833096e651cb88f7282a