### PR TITLE
Fix CI Windows - scripts PS1 + upgrade pip via python -m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Assert scripts present
         shell: pwsh
         run: |
-          Get-ChildItem -Recurse PS1 | Out-String | Write-Host
+          if (-not (Test-Path "PS1")) { Write-Error "Dossier PS1 manquant" ; exit 1 }
           if (-not (Test-Path "PS1/setup.ps1")) { Write-Error "PS1/setup.ps1 manquant" ; exit 1 }
           if (-not (Test-Path "PS1/run_bg.ps1")) { Write-Error "PS1/run_bg.ps1 manquant" ; exit 1 }
           if (-not (Test-Path "PS1/smoke_auth.ps1")) { Write-Error "PS1/smoke_auth.ps1 manquant" ; exit 1 }

--- a/PS1/setup.ps1
+++ b/PS1/setup.ps1
@@ -2,11 +2,20 @@ Param(
     [string]$PythonExe = "python"
 )
 $ErrorActionPreference = "Stop"
+
 Write-Host "Creation venv..." -ForegroundColor Cyan
 & $PythonExe -m venv .venv
 if ($LASTEXITCODE -ne 0) { Write-Error "Echec creation venv" ; exit 1 }
-.\.venv\Scripts\pip.exe install -U pip
+
+$Vpy = ".\.venv\Scripts\python.exe"
+$Pip = ".\.venv\Scripts\pip.exe"
+
+Write-Host "Upgrade pip (via python -m)..." -ForegroundColor Cyan
+& $Vpy -m pip install --upgrade pip
 if ($LASTEXITCODE -ne 0) { Write-Error "Echec upgrade pip" ; exit 1 }
-.\.venv\Scripts\pip.exe install -e backend[dev]
+
+Write-Host "Installation des dependances (editable)..." -ForegroundColor Cyan
+& $Pip install -e backend[dev]
 if ($LASTEXITCODE -ne 0) { Write-Error "Echec installation deps" ; exit 1 }
+
 Write-Host "OK: environnement pret." -ForegroundColor Green


### PR DESCRIPTION
## Summary
- fix Windows setup.ps1 to upgrade pip via `python -m pip`
- verify PS1 scripts exist before running Windows smoke tests

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `DEV_USER=admin DEV_PASSWORD=admin123 pytest -q --cov=backend`


------
https://chatgpt.com/codex/tasks/task_e_68a5f554b1208330987cc796b4ec9c67