### PR TITLE
ETAPE 5 - Alembic + PostgreSQL + CI Postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Application
+
 APP_NAME=Coulisses Crew API
 APP_ENV=dev
 APP_HOST=0.0.0.0
@@ -7,18 +9,26 @@ APP_DEFAULT_PAGE_SIZE=50
 APP_MAX_PAGE_SIZE=200
 APP_REQUEST_TIMEOUT_SECONDS=15
 
+# Security
+
 JWT_SECRET=changeme-dev
 JWT_ALGO=HS256
 JWT_TTL_SECONDS=3600
-CORS_ORIGINS=http://localhost:3000,http://localhost:5173
+CORS_ORIGINS=[http://localhost:3000,http://localhost:5173]
+
+# Admin autoseed
 
 ADMIN_AUTOSEED=true
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=admin123
+
+# DB (par defaut SQLite)
 
 DB_DSN=sqlite:///./cc.db
 DB_POOL_SIZE=10
 DB_MAX_OVERFLOW=20
 DB_POOL_TIMEOUT=10
 
-VITE_API_BASE_URL=http://localhost:8001
+# Exemple DSN Postgres (activer en remplacant DB_DSN ci-dessus)
+
+# DB_DSN=postgresql+psycopg://app:app@localhost:5432/app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,19 +5,16 @@ on:
 jobs:
   backend:
     runs-on: ubuntu-latest
-    strategy:
-      matrix: { python-version: ["3.11"] }
+    strategy: { matrix: { python-version: ["3.11"] } }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - name: Install
+        with: { python-version: ${{ matrix.python-version }}, cache: "pip" }
+      - name: Install backend
         run: |
           python -m pip install --upgrade pip
           pip install -e backend[dev]
-      - name: Create .env (defaults for CI)
+      - name: Create .env (defaults for CI, SQLite)
         run: |
           echo "APP_ENV=ci" >> .env
           echo "APP_LOG_LEVEL=info" >> .env
@@ -27,13 +24,13 @@ jobs:
           echo "JWT_SECRET=ci-secret" >> .env
           echo "JWT_ALGO=HS256" >> .env
           echo "JWT_TTL_SECONDS=3600" >> .env
-          echo "CORS_ORIGINS=http://localhost:3000,http://localhost:5173" >> .env
+          echo "CORS_ORIGINS=[http://localhost:3000,http://localhost:5173]" >> .env
           echo "DB_DSN=sqlite:///./cc.db" >> .env
-      - name: Lint
+      - name: Lint backend
         run: |
           python -m ruff check backend
           python -m mypy backend
-      - name: Tests
+      - name: Test backend (SQLite)
         env:
           ADMIN_AUTOSEED: "true"
           ADMIN_USERNAME: "admin"
@@ -47,13 +44,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with: { python-version: "3.11", cache: "pip" }
-      - name: Assert scripts present
+      - name: Assert PS1
         shell: pwsh
         run: |
           if (-not (Test-Path "PS1/setup.ps1")) { Write-Error "PS1/setup.ps1 manquant" ; exit 1 }
           if (-not (Test-Path "PS1/run_bg.ps1")) { Write-Error "PS1/run_bg.ps1 manquant" ; exit 1 }
           if (-not (Test-Path "PS1/smoke_auth.ps1")) { Write-Error "PS1/smoke_auth.ps1 manquant" ; exit 1 }
-      - name: Create .env (defaults for CI)
+      - name: Create .env
         shell: pwsh
         run: |
           @"
@@ -65,25 +62,24 @@ ADMIN_PASSWORD=admin123
 JWT_SECRET=ci-secret
 JWT_ALGO=HS256
 JWT_TTL_SECONDS=3600
-CORS_ORIGINS=http://localhost:3000,http://localhost:5173
-
+CORS_ORIGINS=[http://localhost:3000,http://localhost:5173]
 DB_DSN=sqlite:///./cc.db
 "@ | Out-File -FilePath .env -Encoding ascii
-      - name: Initialize environment
+      - name: Setup venv
         shell: pwsh
         run: ./PS1/setup.ps1
       - name: Start API (bg)
         shell: pwsh
         run: ./PS1/run_bg.ps1
-      - name: Smoke auth (PowerShell)
+      - name: Smoke auth (API)
         shell: pwsh
         run: ./PS1/smoke_auth.ps1
   compose_smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
-      - name: Create .env (defaults for CI)
+      - name: Create .env (Postgres compose)
         run: |
           echo "APP_ENV=ci" >> .env
           echo "APP_LOG_LEVEL=info" >> .env
@@ -93,8 +89,8 @@ DB_DSN=sqlite:///./cc.db
           echo "JWT_SECRET=ci-secret" >> .env
           echo "JWT_ALGO=HS256" >> .env
           echo "JWT_TTL_SECONDS=3600" >> .env
-          echo "CORS_ORIGINS=http://localhost:3000,http://localhost:5173" >> .env
-          echo "DB_DSN=sqlite:///./cc.db" >> .env
+          echo "CORS_ORIGINS=[http://localhost:3000,http://localhost:5173]" >> .env
+          echo "DB_DSN=postgresql+psycopg://app:app@db:5432/app" >> .env
       - name: Build and run compose (skip if docker unavailable)
         run: |
           if ! command -v docker >/dev/null 2>&1; then
@@ -102,10 +98,47 @@ DB_DSN=sqlite:///./cc.db
             exit 0
           fi
           docker compose up -d --build
-          sleep 7
+          sleep 10
           code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8001/healthz)
           echo "HTTP=$code"
           test "$code" = "200"
+  postgres_tests:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: pgdb
+          POSTGRES_USER: pguser
+          POSTGRES_PASSWORD: pgpass
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U pguser -d pgdb"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11", cache: "pip" }
+      - name: Install backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e backend[dev]
+      - name: Alembic upgrade (Postgres)
+        env:
+          DB_DSN: postgresql+psycopg://pguser:pgpass@localhost:5432/pgdb
+        run: |
+          python -m alembic upgrade head
+      - name: Run tests against Postgres
+        env:
+          DB_DSN: postgresql+psycopg://pguser:pgpass@localhost:5432/pgdb
+          ADMIN_AUTOSEED: "true"
+          ADMIN_USERNAME: "admin"
+          ADMIN_PASSWORD: "admin123"
+        run: |
+          pytest -q -k "auth_db or users_api"
   frontend:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/PS1/alembic_downgrade.ps1
+++ b/PS1/alembic_downgrade.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = "Stop"
+Param([string]$Rev = "-1")
+if (-not (Test-Path .venv\Scripts\python.exe)) { Write-Error "Venv manquante. PS1\setup.ps1" ; exit 1 }
+Write-Host "Downgrade DB -> $Rev ..." -ForegroundColor Yellow
+.venv\Scripts\python.exe -m alembic downgrade $Rev
+Write-Host "OK downgrade." -ForegroundColor Green

--- a/PS1/alembic_revision.ps1
+++ b/PS1/alembic_revision.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = "Stop"
+Param([string]$Msg = "change")
+if (-not (Test-Path .venv\Scripts\python.exe)) { Write-Error "Venv manquante. PS1\setup.ps1" ; exit 1 }
+Write-Host "Nouvelle revision: $Msg" -ForegroundColor Cyan
+.venv\Scripts\python.exe -m alembic revision -m "$Msg"
+Write-Host "OK revision creee." -ForegroundColor Green

--- a/PS1/alembic_upgrade.ps1
+++ b/PS1/alembic_upgrade.ps1
@@ -1,0 +1,5 @@
+$ErrorActionPreference = "Stop"
+if (-not (Test-Path .venv\Scripts\python.exe)) { Write-Error "Venv manquante. PS1\setup.ps1" ; exit 1 }
+Write-Host "Migration DB -> head..." -ForegroundColor Cyan
+.venv\Scripts\python.exe -m alembic upgrade head
+Write-Host "OK migrations appliquees." -ForegroundColor Green

--- a/PS1/compose_up.ps1
+++ b/PS1/compose_up.ps1
@@ -1,3 +1,7 @@
 $ErrorActionPreference = "Stop"
+if (-not (Test-Path .env)) {
+    Write-Host "Avertissement: .env absent. Copie .env.example -> .env" -ForegroundColor Yellow
+    Copy-Item .env.example .env
+}
 docker compose up -d --build
 Write-Host "API dispo: http://localhost:8001/healthz" -ForegroundColor Green

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./cc.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from backend.app.db import Base  # type: ignore
+
+# this is the Alembic Config object
+config = context.config
+
+# Override DSN from ENV if present
+env_dsn = os.getenv("DB_DSN")
+if env_dsn:
+    config.set_main_option("sqlalchemy.url", env_dsn)
+
+# Interpret the config file for Python logging.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True, compare_type=True
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/20250820_0001_initial.py
+++ b/alembic/versions/20250820_0001_initial.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20250820_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("username", sa.String(length=64), nullable=False, unique=True),
+        sa.Column("password_hash", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_users_username", "users", ["username"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_username", table_name="users")
+    op.drop_table("users")

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,21 +1,19 @@
-# Coulisses Crew API (ETAPE 3)
+# ETAPE 5 - Alembic + PostgreSQL
 
-Persistence SQLite + Users en DB + Auth via DB + autoseed admin.
+* SQLite par defaut pour le dev rapide
+* Postgres via DB_DSN et docker-compose (service db)
+* Alembic: upgrade/downgrade/revision
 
-## Endpoints
+## PowerShell (Windows)
 
-* GET /healthz
-* POST /auth/token
-* GET /auth/me
-* GET /users (Bearer)
-* POST /users (Bearer)
+PS> .\PS1\setup.ps1
+PS> .\PS1\alembic_upgrade.ps1
+PS> .\PS1\run_bg.ps1
 
-## Local Windows
+## Docker Compose (Postgres)
 
-PS1\setup.ps1
+PS> Copy-Item .env.example .env
 
-PS1\run.ps1 ou PS1\run_bg.ps1
+# Optionnel: setx DB_DSN "postgresql+psycopg://app:app@localhost:5432/app"
 
-PS1\db_reset.ps1, PS1\db_seed_admin.ps1
-
-PS1\smoke_auth.ps1
+PS> .\PS1\compose_up.ps1

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -15,7 +15,7 @@ class HealthModel(BaseModel):
 
 @router.get("/healthz", response_model=HealthModel, tags=["health"])
 def healthz():
-    return {"status": "ok", "version": "0.3.0"}
+    return {"status": "ok", "version": "0.5.0"}
 
 
 class EchoIn(BaseModel):

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from typing import Any
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
@@ -12,18 +13,18 @@ class Base(DeclarativeBase):
     pass
 
 
-connect_args: dict[str, object] = {}
-engine_args: dict[str, object] = {}
-if settings.DB_DSN.startswith("sqlite"):
-    connect_args = {"check_same_thread": False}
-else:
-    engine_args = {
-        "pool_size": settings.DB_POOL_SIZE,
-        "max_overflow": settings.DB_MAX_OVERFLOW,
-        "pool_timeout": settings.DB_POOL_TIMEOUT,
-    }
+def _engine_kwargs() -> dict[str, Any]:
+    kw: dict[str, Any] = {}
+    if settings.DB_DSN.startswith("sqlite"):
+        kw["connect_args"] = {"check_same_thread": False}
+    else:
+        kw["pool_size"] = settings.DB_POOL_SIZE
+        kw["max_overflow"] = settings.DB_MAX_OVERFLOW
+        kw["pool_timeout"] = settings.DB_POOL_TIMEOUT
+    return kw
 
-engine = create_engine(settings.DB_DSN, connect_args=connect_args, **engine_args)
+
+engine = create_engine(settings.DB_DSN, **_engine_kwargs())
 
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coulisses-crew-api"
-version = "0.3.0"
+version = "0.5.0"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi==0.115.0",
@@ -14,6 +14,8 @@ dependencies = [
     "pyjwt==2.9.0",
     "SQLAlchemy==2.0.32",
     "passlib[bcrypt]==1.7.4",
+    "alembic==1.13.2",
+    "psycopg[binary]==3.2.1",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -9,6 +9,7 @@ def test_health_ok() -> None:
     r = client.get("/healthz")
     assert r.status_code == 200
     assert r.json()["status"] == "ok"
+    assert r.json()["version"] == "0.5.0"
 
 
 def test_unknown_path_404() -> None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,28 @@
 services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-app}
+      POSTGRES_USER: ${POSTGRES_USER:-app}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-app}
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-app} -d ${POSTGRES_DB:-app}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
   api:
     build:
       context: .
       dockerfile: Dockerfile.backend
     env_file:
       - .env
+    environment:
+      DB_DSN: ${DB_DSN:-postgresql+psycopg://app:app@db:5432/app}
+    depends_on:
+      db:
+        condition: service_healthy
     ports:
       - "8001:8001"
     restart: unless-stopped

--- a/scripts/bash/alembic_upgrade.sh
+++ b/scripts/bash/alembic_upgrade.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${DB_DSN:=sqlite:///./cc.db}"
+python -m alembic upgrade head
+echo "Migrations OK"


### PR DESCRIPTION
## Summary
- add Alembic config and initial migration
- support Postgres via configurable DB_DSN
- wire Postgres into compose and CI with dedicated job

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `python -m alembic upgrade head`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a619bb62248330b54e4d9cf7744394