### PR TITLE
ETAPE 8 - /users: pagination meta + tri + ETag/304

### DIFF
--- a/PS1/smoke_users_cache.ps1
+++ b/PS1/smoke_users_cache.ps1
@@ -1,0 +1,23 @@
+$ErrorActionPreference = "Stop"
+$Base = "http://localhost:8001"
+
+# Login admin (tente mdp actuel puis fallback secretXYZ)
+
+function Get-Token {
+param([string]$U,[string]$P)
+try {
+$r = Invoke-RestMethod -Uri "$Base/auth/token" -Method POST -ContentType application/json -Body (@{username=$U;password=$P} | ConvertTo-Json)
+return $r.access_token
+} catch { return $null }
+}
+$tok = Get-Token -U "admin" -P "admin123"
+if (-not $tok) { $tok = Get-Token -U "admin" -P "secretXYZ" }
+if (-not $tok) { Write-Error "Impossible d obtenir un token admin" ; exit 1 }
+
+$headers = @{ Authorization = "Bearer $tok" }
+$r1 = Invoke-WebRequest -Uri "$Base/users?order=username_asc" -Headers $headers -TimeoutSec 10 -Method GET
+$etag = $r1.Headers["ETag"]
+"ETag recu: $etag"
+$r2 = Invoke-WebRequest -Uri "$Base/users?order=username_asc" -Headers (@{ Authorization = "Bearer $tok"; "If-None-Match" = $etag }) -TimeoutSec 10 -Method GET -ErrorAction SilentlyContinue
+if ($r2.StatusCode -ne 304) { Write-Error "304 attendu, recu $($r2.StatusCode)" ; exit 1 }
+Write-Host "Cache 304 OK" -ForegroundColor Green

--- a/alembic/versions/20250821_0003_users_updated_at.py
+++ b/alembic/versions/20250821_0003_users_updated_at.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers
+revision = "20250821_0003"
+down_revision = "20250820_0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "updated_at")

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -15,7 +15,7 @@ class HealthModel(BaseModel):
 
 @router.get("/healthz", response_model=HealthModel, tags=["health"])
 def healthz():
-    return {"status": "ok", "version": "0.7.0"}
+    return {"status": "ok", "version": "0.8.0"}
 
 
 class EchoIn(BaseModel):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -15,3 +15,6 @@ class User(Base):
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     role: Mapped[str] = mapped_column(String(16), nullable=False, default="user")
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -13,10 +13,23 @@ class UserOut(BaseModel):
 
 
 class UserCreateIn(BaseModel):
-    username: str = Field(min_length=2, max_length=64)
+    username: str = Field(min_length=3, max_length=64)
     password: str = Field(min_length=6, max_length=128)
 
 
 class ChangePasswordIn(BaseModel):
-    old_password: str = Field(min_length=1)
+    old_password: str = Field(min_length=6)
     new_password: str = Field(min_length=6, max_length=128)
+
+
+class PageMeta(BaseModel):
+    total: int
+    pages: int
+    page: int
+    page_size: int
+    etag: str
+
+
+class UsersListOut(BaseModel):
+    meta: PageMeta
+    data: list[UserOut]

--- a/backend/app/users_api.py
+++ b/backend/app/users_api.py
@@ -1,25 +1,61 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
+import hashlib
+from math import ceil
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from .deps import get_db, pagination_params, require_admin
 from .hash import hash_password
-from .repo_users import create_user, get_by_username, list_users, promote_to_admin
-from .schemas import UserCreateIn, UserOut
+from .repo_users import (
+    count_users,
+    create_user,
+    get_by_username,
+    last_ts_users,
+    list_users,
+)
+from .schemas import PageMeta, UserCreateIn, UserOut, UsersListOut
 
 router = APIRouter()
 
 
-@router.get("/users", response_model=list[UserOut], tags=["users"])
+def _compute_etag(
+    total: int, last_ts: object | None, page: int, page_size: int, order: str
+) -> str:
+    last_str = str(last_ts) if last_ts is not None else "0"
+    raw = f"{total}:{last_str}:{page}:{page_size}:{order}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+@router.get("/users", response_model=UsersListOut, tags=["users"])
 def users_list(
+    response: Response,
     pg=Depends(pagination_params),  # noqa: B008
     db: Session = Depends(get_db),  # noqa: B008
     _: dict = Depends(require_admin),  # noqa: B008
-) -> list[UserOut]:
-    offset = (pg["page"] - 1) * pg["page_size"]
-    items = list_users(db, offset=offset, limit=pg["page_size"])
-    return [UserOut.model_validate(i) for i in items]
+    order: str = Query(default="created_desc", pattern="^(created|username)_(asc|desc)$"),
+    if_none_match: str | None = Header(default=None, alias="If-None-Match"),
+) -> UsersListOut | Response:
+    total = count_users(db)
+    pages = ceil(max(total, 1) / pg["page_size"])
+    page = min(max(pg["page"], 1), max(pages, 1))
+    items = list_users(
+        db,
+        offset=(page - 1) * pg["page_size"],
+        limit=pg["page_size"],
+        order=order,
+    )
+    last_ts = last_ts_users(db)
+    etag = _compute_etag(total, last_ts, page, pg["page_size"], order)
+    if if_none_match and if_none_match == etag:
+        response.headers["ETag"] = etag
+        response.headers["Cache-Control"] = "private, max-age=30"
+        return Response(status_code=304)
+    response.headers["ETag"] = etag
+    response.headers["Cache-Control"] = "private, max-age=30"
+    meta = PageMeta(total=total, pages=pages, page=page, page_size=pg["page_size"], etag=etag)
+    return UsersListOut(meta=meta, data=[UserOut.model_validate(i) for i in items])
 
 
 @router.post("/users", response_model=UserOut, status_code=201, tags=["users"])
@@ -41,9 +77,10 @@ def users_promote(
     db: Session = Depends(get_db),  # noqa: B008
     _: dict = Depends(require_admin),  # noqa: B008
 ) -> UserOut:
+    from .repo_users import promote_to_admin  # import tardif pour limiter cycles
+
     u = promote_to_admin(db, username)
     if not u:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Utilisateur introuvable")
     db.commit()
     return UserOut.model_validate(u)
-

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coulisses-crew-api"
-version = "0.7.0"
+version = "0.8.0"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi==0.115.0",

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -9,7 +9,7 @@ def test_health_ok() -> None:
     r = client.get("/healthz")
     assert r.status_code == 200
     assert r.json()["status"] == "ok"
-    assert r.json()["version"] == "0.7.0"
+    assert r.json()["version"] == "0.8.0"
 
 
 def test_unknown_path_404() -> None:

--- a/backend/tests/test_health_version.py
+++ b/backend/tests/test_health_version.py
@@ -5,8 +5,8 @@ from app.main import app
 client = TestClient(app)
 
 
-def test_health_version_070():
+def test_health_version_080():
     r = client.get("/healthz")
     assert r.status_code == 200
-    assert r.json()["version"].startswith("0.7.0")
+    assert r.json()["version"].startswith("0.8.0")
 

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -25,6 +25,8 @@ def test_users_list_and_create_ok_ko():
     t = _token()
     r = client.get("/users", headers={"Authorization": f"Bearer {t}"})
     assert r.status_code == 200
+    j = r.json()
+    assert "meta" in j and "data" in j
     r2 = client.post(
         "/users",
         headers={"Authorization": f"Bearer {t}"},

--- a/backend/tests/test_users_pagination_cache.py
+++ b/backend/tests/test_users_pagination_cache.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.main import app
+
+client = TestClient(app)
+
+
+def _login(u: str, p: str):
+    return client.post("/auth/token", json={"username": u, "password": p})
+
+
+def _adm_token():
+    pwd = settings.ADMIN_PASSWORD if settings.ADMIN_PASSWORD else "admin123"
+    r = _login(settings.ADMIN_USERNAME, pwd)
+    if r.status_code != 200:
+        # Possiblement l admin a change son mot de passe a l ETAPE 6 tests -> tenter secretXYZ
+        r = _login(settings.ADMIN_USERNAME, "secretXYZ")
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+def test_users_pagination_and_meta_and_etag_304():
+    t = _adm_token()
+    # 1er appel -> 200 + ETag
+    r1 = client.get("/users?order=username_asc", headers={"Authorization": f"Bearer {t}"})
+    assert r1.status_code == 200
+    assert "ETag" in r1.headers
+    etag = r1.headers["ETag"]
+    j = r1.json()
+    assert "meta" in j and "data" in j
+    assert j["meta"]["page"] >= 1
+    assert j["meta"]["page_size"] >= 1
+    assert j["meta"]["etag"] == etag
+    # 2nd appel avec If-None-Match -> 304
+    r2 = client.get(
+        "/users?order=username_asc",
+        headers={"Authorization": f"Bearer {t}", "If-None-Match": etag},
+    )
+    assert r2.status_code == 304
+
+
+def test_users_sorting_orders():
+    t = _adm_token()
+    # creer deux utilisateurs pour tester tri
+    client.post(
+        "/users",
+        headers={"Authorization": f"Bearer {t}"},
+        json={"username": "aaatest", "password": "x123456"},
+    )
+    client.post(
+        "/users",
+        headers={"Authorization": f"Bearer {t}"},
+        json={"username": "zzzztest", "password": "x123456"},
+    )
+    r_asc = client.get(
+        "/users?order=username_asc&page_size=1",
+        headers={"Authorization": f"Bearer {t}"},
+    )
+    assert r_asc.status_code == 200
+    first_asc = r_asc.json()["data"][0]["username"]
+    r_desc = client.get(
+        "/users?order=username_desc&page_size=1",
+        headers={"Authorization": f"Bearer {t}"},
+    )
+    assert r_desc.status_code == 200
+    first_desc = r_desc.json()["data"][0]["username"]
+    assert first_asc <= first_desc


### PR DESCRIPTION
## Summary
- add `updated_at` to users table with migration
- extend /users with paging metadata, sorting and per-page ETag/304 handling
- expose API version 0.8.0 and add tests & smoke script for caching

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `cd backend && python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6365c9c2c83308dfb80c5d091f265