### PR TITLE
Fix tests - disable rate limit and align versions

### DIFF
--- a/PS1/e2e_run.ps1
+++ b/PS1/e2e_run.ps1
@@ -1,22 +1,28 @@
 $ErrorActionPreference = "Stop"
-
 if (-not (Test-Path .env)) { Copy-Item .env.example .env }
-$env:APP_ENV = "ci"
-$env:ADMIN_AUTOSEED = "true"
-$env:ADMIN_USERNAME = "admin"
-if (-not $env:ADMIN_PASSWORD) { $env:ADMIN_PASSWORD = "admin123" }
+$env:APP_ENV="ci"
+$env:ADMIN_AUTOSEED="true"
+$env:ADMIN_USERNAME="admin"
+if (-not $env:ADMIN_PASSWORD) { $env:ADMIN_PASSWORD="admin123" }
 
-try {
-  $code = (Invoke-WebRequest -Uri "http://localhost:8001/healthz" -TimeoutSec 3 -ErrorAction Stop).StatusCode
-} catch { $code = 0 }
-if ($code -ne 200) {
-  .\PS1\setup.ps1
-  Start-Process -WindowStyle Hidden -FilePath python -ArgumentList "-m","uvicorn","app.main:app","--app-dir","backend","--host","0.0.0.0","--port","8001"
-  Start-Sleep -Seconds 5
+# Demarrer backend si healthz != 200
+function Get-Health { try { (Invoke-WebRequest -Uri "http://localhost:8001/healthz" -TimeoutSec 3 -ErrorAction Stop).StatusCode } catch { 0 } }
+if ((Get-Health) -ne 200) {
+    .\PS1\setup.ps1
+    Start-Process -WindowStyle Hidden -FilePath python -ArgumentList "-m","uvicorn","app.main:app","--app-dir","backend","--host","0.0.0.0","--port","8001"
+    Start-Sleep -Seconds 5
 }
 
+# Auto-install des browsers si manquants
 Push-Location web
-$env:CI = "1"
+try {
+    $list = npx playwright browsers ls
+    if ($list -notmatch "chromium") {
+        npx playwright install chromium
+    }
+} catch {
+    npx playwright install chromium
+}
 npm run build
 npx playwright test
 Pop-Location

--- a/PS1/e2e_setup.ps1
+++ b/PS1/e2e_setup.ps1
@@ -2,6 +2,19 @@ $ErrorActionPreference = "Stop"
 if (-not (Test-Path .\web\package.json)) { Write-Error "Dossier web introuvable" ; exit 1 }
 Push-Location web
 npm ci
-npx playwright install --with-deps
+
+# 3 tentatives d install du navigateur
+$ok = $false
+for ($i=1; $i -le 3; $i++) {
+    try {
+        npx playwright install chromium --with-deps
+        $ok = $true
+        break
+    } catch {
+        Write-Warning "Retry playwright install ($i/3)..."
+        Start-Sleep -Seconds 3
+    }
+}
+if (-not $ok) { Write-Error "Echec installation Chromium apres 3 tentatives." ; exit 1 }
 Pop-Location
 Write-Host "Playwright installe." -ForegroundColor Green

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from app.config import settings
+
+# Initial toggles before importing app in tests
+settings.RATE_LIMIT_ENABLE = False
+settings.RATE_LIMIT_GLOBAL_MAX = 10_000
+settings.RATE_LIMIT_AUTH_MAX = 10_000
+settings.ADMIN_AUTOSEED = True
+settings.ADMIN_USERNAME = "admin"
+settings.ADMIN_PASSWORD = "admin123"
+os.environ.setdefault("CORS_ORIGINS", "http://localhost:3000,http://localhost:5173")
+
+
+@pytest.fixture(autouse=True)
+def _test_env_toggles() -> Iterator[None]:
+    settings.RATE_LIMIT_ENABLE = False
+    settings.RATE_LIMIT_GLOBAL_MAX = 10_000
+    settings.RATE_LIMIT_AUTH_MAX = 10_000
+    settings.ADMIN_AUTOSEED = True
+    settings.ADMIN_USERNAME = "admin"
+    settings.ADMIN_PASSWORD = "admin123"
+    os.environ.setdefault(
+        "CORS_ORIGINS", "http://localhost:3000,http://localhost:5173"
+    )
+    yield

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -9,7 +9,7 @@ def test_health_ok() -> None:
     r = client.get("/healthz")
     assert r.status_code == 200
     assert r.json()["status"] == "ok"
-    assert r.json()["version"] == "0.8.0"
+    assert r.json()["version"].startswith("0.9.0")
 
 
 def test_unknown_path_404() -> None:

--- a/scripts/bash/e2e_run.sh
+++ b/scripts/bash/e2e_run.sh
@@ -17,5 +17,10 @@ if [ "$code" != "200" ]; then
   sleep 5
 fi
 
-# E2E
+# Tenter auto-install chromium si absent
+if ! npx playwright browsers ls | grep -qi chromium; then
+  npx playwright install chromium || true
+fi
+
+# Lancer E2E
 ( cd web && npm run build && npx playwright test )

--- a/scripts/bash/e2e_setup.sh
+++ b/scripts/bash/e2e_setup.sh
@@ -2,5 +2,15 @@
 set -euo pipefail
 cd web
 npm ci
-npx playwright install --with-deps
-echo "Playwright OK"
+
+# Retry downloads (reseau instable). Installe uniquement Chromium pour nos tests.
+for i in 1 2 3; do
+  if npx playwright install chromium --with-deps; then
+    echo "Playwright Chromium installe."
+    exit 0
+  fi
+  echo "Retry playwright install ($i/3)..." >&2
+  sleep 3
+done
+echo "Echec installation Chromium apres 3 tentatives." >&2
+exit 1

--- a/scripts/bash/web_test.sh
+++ b/scripts/bash/web_test.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 cd web
 npm run lint
-npm test
+npm test -- src
 echo "Web tests OK"

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "dev": "vite --host --port 5173",
     "build": "tsc -b && vite build",
     "preview": "vite preview --host --port 5173",
-    "lint": "eslint . --ext .ts,.tsx",
+    "lint": "eslint .",
     "test": "vitest run --coverage",
     "test:e2e": "playwright test"
   },


### PR DESCRIPTION
## Summary
- disable rate limiting during tests and auto-seed admin
- assert API health endpoint reports version 0.9.0
- simplify web lint script and ensure vitest ignores e2e specs
- add retries for Playwright browser installs and auto-install on run

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `pytest -q --cov=backend`
- `bash scripts/bash/web_test.sh`
- `bash scripts/bash/e2e_setup.sh` *(fails: Echec installation Chromium apres 3 tentatives.)*
- `bash scripts/bash/e2e_run.sh` *(hangs: chromium missing)*
- `pwsh -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c717e1148330a135e350c4236d59