### PR TITLE
Fix E2E offline skip + CI Chromium retry strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ DB_DSN=sqlite:///./cc.db
 
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -237,14 +237,22 @@ DB_DSN=sqlite:///./cc.db
           code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8001/healthz)
           echo "HTTP=$code"
           test "$code" = "200"
-      - name: Install Playwright
+      - name: Install Playwright Chromium (strict, retries)
+        working-directory: web
         run: |
-          cd web
           npm ci
-          npx playwright install --with-deps
-      - name: E2E tests (Playwright)
+          for i in 1 2 3; do
+            npx playwright install chromium --with-deps && exit 0
+            echo "Retry install Chromium ($i/3)..." >&2
+            sleep 3
+          done
+          echo "Chromium install failed after retries" >&2
+          exit 1
+      - name: E2E tests
+        working-directory: web
         env:
           ADMIN_PASSWORD: "admin123"
+          E2E_SKIP: "0"
         run: |
-          npm --prefix web run build
-          npx playwright test -c web/playwright.config.ts
+          npm run build
+          npx playwright test

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.egg-info/
 .venv/
 .env
+.e2e_skip.env
 .coverage
 htmlcov/
 .pytest_cache/
@@ -22,3 +23,4 @@ build/
 
 web/node_modules/
 web/dist/
+web/coverage/

--- a/backend/tests/test_e2e_skip.py
+++ b/backend/tests/test_e2e_skip.py
@@ -1,0 +1,17 @@
+import subprocess
+from pathlib import Path
+
+
+def test_e2e_run_respects_skip():
+    skip_file = Path(".e2e_skip.env")
+    skip_file.write_text("E2E_SKIP=1\n")
+    try:
+        result = subprocess.run(
+            ["bash", "scripts/bash/e2e_run.sh"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "E2E SKIP" in result.stdout
+    finally:
+        skip_file.unlink(missing_ok=True)

--- a/scripts/bash/e2e_setup.sh
+++ b/scripts/bash/e2e_setup.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 cd web
 npm ci
+rm -f ../.e2e_skip.env
 
 # 1) Tenter navigateur systeme
 ROOT_DIR="$(cd .. && pwd)"
@@ -13,18 +14,20 @@ fi
 
 # 2) Telechargement Chromium (3 tentatives)
 set +e
+ok=0
 for i in 1 2 3; do
   npx playwright install chromium --with-deps && ok=1 && break
   echo "Retry playwright install chromium ($i/3)..." >&2
   sleep 3
 done
 set -e
-if [ "${ok:-0}" != "1" ]; then
+if [ "$ok" != "1" ]; then
   if [ "${CI:-}" = "true" ]; then
     echo "Echec installation Chromium (CI) -> FAIL" >&2
     exit 1
   else
     echo "Echec installation Chromium (local) -> E2E SKIP" >&2
+    echo "E2E_SKIP=1" > ../.e2e_skip.env
     exit 0
   fi
 fi

--- a/web/e2e/e2e.spec.ts
+++ b/web/e2e/e2e.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 if (process.env.E2E_SKIP === "1") {
-  test.skip(true, "E2E SKIPPED by E2E_SKIP=1");
+  test.skip(true, "E2E SKIP (E2E_SKIP=1)");
 }
 
 const ADMIN_USER = "admin";

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const useSystemChrome = !!process.env.CHROMIUM_EXECUTABLE;
+const launchOptions = process.env.CHROMIUM_EXECUTABLE
+  ? { executablePath: process.env.CHROMIUM_EXECUTABLE }
+  : {};
 
 export default defineConfig({
   testDir: "e2e",
@@ -9,9 +11,7 @@ export default defineConfig({
     baseURL: "http://localhost:5173",
     trace: "on-first-retry",
     headless: true,
-    launchOptions: useSystemChrome
-      ? { executablePath: process.env.CHROMIUM_EXECUTABLE }
-      : {},
+    launchOptions,
   },
   webServer: {
     command: "npm run preview",


### PR DESCRIPTION
## Summary
- handle offline Chromium setup by exporting E2E_SKIP and early exit in e2e run
- retry strict Chromium install in CI e2e job
- add regression test for skip flag

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `pytest -q --cov=backend`
- `bash scripts/bash/web_test.sh`
- `PLAYWRIGHT_DOWNLOAD_HOST=http://127.0.0.1 bash scripts/bash/e2e_setup.sh`
- `bash scripts/bash/e2e_run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a6d420ff788330863b3af51c55dbd3