### PR TITLE
ETAPE 14 - Build front et service statique via backend (SPA)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,7 @@ RATE_LIMIT_AUTH_WINDOW_SECONDS=60
 RATE_LIMIT_BACKEND=memory
 REDIS_URL=redis://localhost:6379/0
 
+# Frontend (SPA build)
+# Chemin vers le dossier de build Vite (web/dist). Vide = pas de montage.
+FRONT_DIST_DIR=
+

--- a/PS1/web_build.ps1
+++ b/PS1/web_build.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = "Stop"
+if (-not (Test-Path .\web\package.json)) { Write-Error "Dossier web introuvable" ; exit 1 }
+Push-Location web
+if (-not (Test-Path .\node_modules)) { npm ci }
+npm run build
+Pop-Location
+if (-not (Test-Path .\web\dist\index.html)) { Write-Error "Build Vite introuvable (web/dist/index.html absent)" ; exit 1 }
+Write-Host "Build front OK. Pour servir via backend:" -ForegroundColor Green
+Write-Host " powershell -Command `$env:FRONT_DIST_DIR='$(Join-Path (Get-Location) 'web\dist')'; python -m uvicorn app.main:app --app-dir backend --port 8001" -ForegroundColor DarkCyan

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -50,5 +50,8 @@ class Settings:
     RATE_LIMIT_BACKEND: str = os.getenv("RATE_LIMIT_BACKEND", "memory")
     REDIS_URL: str = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 
+    # Frontend build (SPA)
+    FRONT_DIST_DIR: str = os.getenv("FRONT_DIST_DIR", "")
+
 
 settings = Settings()

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import time
-from typing import Protocol
+from typing import Any, Protocol, cast
 
 try:
-    import redis  # type: ignore
+    import redis
 except Exception:  # pragma: no cover - optional dependency
-    redis = None  # type: ignore
+    redis = cast(Any, None)
 
 
 class Limiter(Protocol):
@@ -36,7 +36,7 @@ class InMemoryFixedWindowLimiter:
 class RedisFixedWindowLimiter:
     """Redis-based fixed-window limiter using INCR/EXPIRE."""
 
-    def __init__(self, client) -> None:  # type: ignore[no-untyped-def]
+    def __init__(self, client: Any) -> None:
         self.client = client
 
     def allow(self, key: str, max_calls: int, window_seconds: int) -> tuple[bool, int, int]:

--- a/backend/tests/test_static_mount.py
+++ b/backend/tests/test_static_mount.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.main import create_app
+
+
+def test_spa_mount_ok(tmp_path: Path) -> None:
+    dist = tmp_path / "dist"
+    dist.mkdir(parents=True, exist_ok=True)
+    (dist / "index.html").write_text(
+        "<!doctype html><html><body>Hello SPA</body></html>", encoding="utf-8"
+    )
+    settings.FRONT_DIST_DIR = str(dist)
+    try:
+        app = create_app()
+    finally:
+        settings.FRONT_DIST_DIR = ""
+    client = TestClient(app)
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "Hello SPA" in r.text
+
+
+def test_spa_mount_ko_when_missing(tmp_path: Path) -> None:
+    settings.FRONT_DIST_DIR = str(tmp_path / "nope")
+    try:
+        app = create_app()
+    finally:
+        settings.FRONT_DIST_DIR = ""
+    client = TestClient(app)
+    r = client.get("/")
+    assert r.status_code == 404

--- a/scripts/bash/web_build.sh
+++ b/scripts/bash/web_build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd web
+[ -d node_modules ] || npm ci
+npm run build
+cd ..
+test -f web/dist/index.html || { echo "Build Vite introuvable (web/dist/index.html absent)"; exit 1; }
+echo "Build front OK. Pour servir via backend:"
+echo " FRONT_DIST_DIR=\"$(pwd)/web/dist\" python -m uvicorn app.main:app --app-dir backend --port 8001"


### PR DESCRIPTION
## Summary
- mount Vite build as SPA when `FRONT_DIST_DIR` points to a valid directory
- provide cross-platform scripts to build the frontend
- add regression tests for static mount behaviour

## Testing
- `python -m ruff check app tests`
- `python -m mypy app`
- `PYTHONPATH=backend pytest -q --cov=backend/app`
- `bash scripts/bash/web_build.sh`
- `FRONT_DIST_DIR=$(pwd)/web/dist python -m uvicorn app.main:app --app-dir backend --port 8001` (curl `/` and `/livez`)


------
https://chatgpt.com/codex/tasks/task_e_68a7119023b48330bca36bd9c75b3b77