### PR TITLE
ETAPE 16 - Aides d installation PowerShell 7 + fallbacks clairs + README

### DIFF
--- a/PS1/help_missing_pwsh.ps1
+++ b/PS1/help_missing_pwsh.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = "Stop"
+Write-Host "[INFO] pwsh non detecte. Options:" -ForegroundColor Yellow
+Write-Host "  - Windows: .\\PS1\\install_pwsh_on_windows.ps1 (admin, winget/choco)" -ForegroundColor Gray
+Write-Host "  - Linux:   sudo bash scripts/bash/install_pwsh.sh" -ForegroundColor Gray
+Write-Host "Sinon, utilisez les scripts Bash equivalents (scripts/bash/*.sh)" -ForegroundColor Gray
+exit 0

--- a/PS1/install_pwsh_on_windows.ps1
+++ b/PS1/install_pwsh_on_windows.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = "Stop"
+Write-Host "Installation de PowerShell 7 sur Windows" -ForegroundColor Cyan
+
+# 1) winget (recommande)
+try {
+    winget --version | Out-Null
+    Write-Host "winget detecte. Installation..." -ForegroundColor Yellow
+    winget install --id Microsoft.PowerShell -e --source winget --accept-package-agreements --accept-source-agreements
+    Write-Host "PowerShell 7 installe via winget." -ForegroundColor Green
+    pwsh -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion'
+    exit 0
+} catch {
+    Write-Warning "winget non disponible ou echec."
+}
+
+# 2) Chocolatey (alternative)
+try {
+    choco --version | Out-Null
+    Write-Host "Chocolatey detecte. Installation..." -ForegroundColor Yellow
+    choco install powershell-core -y
+    Write-Host "PowerShell 7 installe via Chocolatey." -ForegroundColor Green
+    pwsh -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion'
+    exit 0
+} catch {
+    Write-Warning "Chocolatey non disponible."
+}
+Write-Warning "Ni winget ni choco detecte. Installer manuellement: https://aka.ms/powershell"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Monorepo FastAPI (backend) + React Vite (frontend). Windows-first (PowerShell), 
 - [Back-end (FastAPI)](#back-end-fastapi)
 - [Front-end (Vite React)](#front-end-vite-react)
 - [Docker Compose (Postgres)](#docker-compose-postgres)
+- [PowerShell 7 (pwsh)](#powershell-7-pwsh)
+- [Sans Docker](#sans-docker)
 - [CI GitHub Actions](#ci-github-actions)
 - [Tests et Qualité](#tests-et-qualite)
 - [Observabilité](#observabilite)
@@ -203,6 +205,39 @@ Copy-Item .env.example .env
 cp .env.example .env
 docker compose up -d --build
 curl -sf http://localhost:8001/healthz
+```
+
+## PowerShell 7 (pwsh)
+
+### Linux (Debian/Ubuntu)
+
+```
+sudo bash scripts/bash/install_pwsh.sh
+pwsh -NoProfile -Command "$PSVersionTable.PSVersion"
+```
+
+### Windows
+
+```
+# en PowerShell admin
+./PS1/install_pwsh_on_windows.ps1
+# ou directement:
+winget install --id Microsoft.PowerShell -e
+# ou:
+choco install powershell-core -y
+```
+
+Si pwsh indisponible, utilisez les scripts Bash (`scripts/bash/*.sh`) qui couvrent toutes les taches courantes.
+
+## Sans Docker
+
+Docker n est pas requis pour le dev local:
+
+```
+bash scripts/bash/web_build.sh
+FRONT_DIST_DIR=$(pwd)/web/dist python -m uvicorn app.main:app --app-dir backend --host 0.0.0.0 --port 8001
+# Smoke:
+curl -sf http://localhost:8001/healthz && curl -sf http://localhost:8001/ | head -c 60
 ```
 
 ## CI GitHub Actions

--- a/scripts/bash/docker_run.sh
+++ b/scripts/bash/docker_run.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 if ! command -v docker >/dev/null 2>&1; then
-    echo "Docker non installe. Fallback: bash scripts/bash/web_build.sh && FRONT_DIST_DIR=$(pwd)/web/dist python -m uvicorn app.main:app --app-dir backend --port 8001" >&2
+    echo "Docker non installe." >&2
+    echo "Fallback local :" >&2
+    echo "  1) bash scripts/bash/web_build.sh" >&2
+    echo "  2) FRONT_DIST_DIR=$(pwd)/web/dist python -m uvicorn app.main:app --app-dir backend --host 0.0.0.0 --port 8001" >&2
     exit 0
 fi
 tag=ccapi:local

--- a/scripts/bash/help_missing_pwsh.sh
+++ b/scripts/bash/help_missing_pwsh.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[INFO] 'pwsh' non detecte."
+echo "  - Windows: lancer .\\PS1\\install_pwsh_on_windows.ps1 (admin) ou winget/choco directement."
+echo "  - Linux:   sudo bash scripts/bash/install_pwsh.sh"
+echo "Sinon, utilisez les scripts Bash equivalents (scripts/bash/*.sh)."

--- a/scripts/bash/install_pwsh.sh
+++ b/scripts/bash/install_pwsh.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installe PowerShell 7 (pwsh) sur Debian/Ubuntu via le depot Microsoft.
+
+# Utilisation:
+
+# sudo bash scripts/bash/install_pwsh.sh
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "[ERROR] Ce script doit etre lance en root (sudo)." >&2
+  exit 1
+fi
+. /etc/os-release
+echo "[INFO] Distribution: $NAME $VERSION_ID"
+
+# Dependances
+
+apt-get update -y
+apt-get install -y wget ca-certificates apt-transport-https gnupg lsb-release
+
+# Depot Microsoft
+
+MS_REPO_PKG="packages-microsoft-prod.deb"
+wget -q "https://packages.microsoft.com/config/${ID}/${VERSION_ID}/packages-microsoft-prod.deb" \
+  -O "/tmp/${MS_REPO_PKG}" || {
+  echo "[WARN] URL repo pour ${ID}/${VERSION_ID} indisponible. Tentative fallback Ubuntu 22.04..." >&2
+  wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O "/tmp/${MS_REPO_PKG}"
+}
+dpkg -i "/tmp/${MS_REPO_PKG}"
+apt-get update -y
+
+# Installer PowerShell 7
+
+apt-get install -y powershell
+echo "[OK] pwsh installe. Version:"
+pwsh -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion'


### PR DESCRIPTION
## Summary
- document PowerShell 7 installation paths and no-Docker workflow in README
- add pwsh install helpers for Debian/Ubuntu and Windows, plus missing-pwsh guides
- improve docker_run.sh fallback message when Docker isn't available

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `PYTHONPATH=backend pytest -q --cov=backend`
- `bash scripts/bash/help_missing_pwsh.sh`
- `pwsh -NoLogo -NoProfile -File PS1/help_missing_pwsh.ps1`
- `bash scripts/bash/install_pwsh.sh`
- `bash scripts/bash/docker_run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a7179ad48483309d2caa329bcf4490