### PR TITLE
ETAPE 20 - CLI Admin (users) + wrappers PS1/Bash + tests

### DIFF
--- a/PS1/ccadmin.ps1
+++ b/PS1/ccadmin.ps1
@@ -1,0 +1,21 @@
+param(
+    [Parameter(Mandatory=$true)][ValidateSet("list","create","promote","reset-password")] [string]$Command,
+    [string]$Username,
+    [string]$Password,
+    [string]$Role,
+    [string]$NewPassword
+)
+$ErrorActionPreference = "Stop"
+
+# Utilise le binaire installe par pip (console_scripts) si dispo, sinon fallback python -m
+function Invoke-CCAdmin {
+    param([string[]]$Args)
+    try { & ccadmin @Args ; return } catch { }
+    python -m app.cli @Args
+}
+switch ($Command) {
+    "list"           { Invoke-CCAdmin @("list") }
+    "create"         { Invoke-CCAdmin @("create","--username",$Username,"--password",$Password, @("--role",$Role) ) }
+    "promote"        { Invoke-CCAdmin @("promote","--username",$Username) }
+    "reset-password" { Invoke-CCAdmin @("reset-password","--username",$Username,"--new-password",$NewPassword) }
+}

--- a/PS1/examples/cli_examples.ps1
+++ b/PS1/examples/cli_examples.ps1
@@ -1,0 +1,11 @@
+# Lister
+powershell -File .\PS1\ccadmin.ps1 -Command list
+
+# Creer user
+powershell -File .\PS1\ccadmin.ps1 -Command create -Username alice -Password pw
+
+# Promouvoir
+powershell -File .\PS1\ccadmin.ps1 -Command promote -Username alice
+
+# Reset password
+powershell -File .\PS1\ccadmin.ps1 -Command reset-password -Username alice -NewPassword newpw

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from .config import settings  # noqa: F401 - ensure settings are loaded
+from .db import session_scope
+from .hash import hash_password
+from .repo_users import create_user as repo_create_user
+from .repo_users import get_by_username
+from .repo_users import list_users as repo_list_users
+
+OK = 0
+ERR = 1
+
+def _json_out(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, ensure_ascii=True))
+
+def cmd_list(args: argparse.Namespace) -> int:
+    with session_scope() as db:
+        users = repo_list_users(db, offset=0, limit=10_000)
+        items: list[dict[str, Any]] = [
+            {"username": u.username, "role": getattr(u, "role", "user")} for u in users
+        ]
+        _json_out({"items": items})
+    return OK
+
+def cmd_create(args: argparse.Namespace) -> int:
+    username = args.username
+    password = args.password
+    role = args.role or "user"
+    if not username or not password:
+        _json_out({"error": "username/password requis"})
+        return ERR
+    with session_scope() as db:
+        if get_by_username(db, username):
+            _json_out({"error": "Utilisateur existe deja", "code": "conflict"})
+            return ERR
+        u = repo_create_user(db, username, hash_password(password), role=role)
+        _json_out({"created": {"username": u.username, "role": u.role}})
+    return OK
+
+def cmd_promote(args: argparse.Namespace) -> int:
+    username = args.username
+    with session_scope() as db:
+        u = get_by_username(db, username)
+        if not u:
+            _json_out({"error": "Utilisateur introuvable"})
+            return ERR
+        u.role = "admin"  # type: ignore[attr-defined]
+        db.add(u)
+        _json_out({"promoted": {"username": u.username, "role": "admin"}})
+    return OK
+
+def cmd_reset_password(args: argparse.Namespace) -> int:
+    username = args.username
+    new_pw = args.new_password
+    if not new_pw:
+        _json_out({"error": "new-password requis"})
+        return ERR
+    with session_scope() as db:
+        u = get_by_username(db, username)
+        if not u:
+            _json_out({"error": "Utilisateur introuvable"})
+            return ERR
+        from .hash import hash_password as _hp
+
+        u.password_hash = _hp(new_pw)
+        db.add(u)
+        _json_out({"password_reset": {"username": u.username}})
+    return OK
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="ccadmin", description="CLI admin utilisateurs")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp_list = sub.add_parser("list", help="Lister les utilisateurs")
+    sp_list.set_defaults(func=cmd_list)
+
+    sp_create = sub.add_parser("create", help="Creer un utilisateur")
+    sp_create.add_argument("--username", required=True)
+    sp_create.add_argument("--password", required=True)
+    sp_create.add_argument("--role", choices=["user", "admin"])
+    sp_create.set_defaults(func=cmd_create)
+
+    sp_prom = sub.add_parser("promote", help="Promouvoir un utilisateur en admin")
+    sp_prom.add_argument("--username", required=True)
+    sp_prom.set_defaults(func=cmd_promote)
+
+    sp_reset = sub.add_parser("reset-password", help="Reinitialiser le mot de passe")
+    sp_reset.add_argument("--username", required=True)
+    sp_reset.add_argument("--new-password", required=True)
+    sp_reset.set_defaults(func=cmd_reset_password)
+
+    return p
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,6 +31,9 @@ dev = [
     "fakeredis==2.23.3",
 ]
 
+[project.scripts]
+ccadmin = "app.cli:main"
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"

--- a/backend/tests/test_cli_admin.py
+++ b/backend/tests/test_cli_admin.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from app.cli import main as cli_main
+from app.config import settings
+from app.db import session_scope
+from app.main import create_app
+from app.repo_users import get_by_username
+
+
+def _run(args: list[str]) -> tuple[int, dict]:
+    code = cli_main(args)
+    return code, {}
+
+
+def test_cli_create_and_promote_and_list(tmp_path):
+    settings.ADMIN_AUTOSEED = True
+    create_app()
+
+    # create OK
+    code, _ = _run(["create", "--username", "alice", "--password", "pw"])
+    assert code == 0
+    with session_scope() as db:
+        u = get_by_username(db, "alice")
+        assert u is not None and getattr(u, "role", "user") == "user"
+
+    # promote OK
+    code, _ = _run(["promote", "--username", "alice"])
+    assert code == 0
+    with session_scope() as db:
+        u = get_by_username(db, "alice")
+        assert u is not None and getattr(u, "role", "user") == "admin"
+
+    # list OK
+    code, _ = _run(["list"])
+    assert code == 0
+
+
+def test_cli_create_duplicate_ko(tmp_path):
+    settings.ADMIN_AUTOSEED = True
+    create_app()
+    assert _run(["create", "--username", "bob", "--password", "pw"])[0] == 0
+    assert _run(["create", "--username", "bob", "--password", "pw"])[0] == 1

--- a/scripts/bash/ccadmin.sh
+++ b/scripts/bash/ccadmin.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cmd="${1:-}"; shift || true
+if command -v ccadmin >/dev/null 2>&1; then
+    ccadmin "$cmd" "$@"
+else
+    python -m app.cli "$cmd" "$@"
+fi

--- a/scripts/bash/examples/cli_examples.sh
+++ b/scripts/bash/examples/cli_examples.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lister
+bash scripts/bash/ccadmin.sh list
+
+# Creer
+bash scripts/bash/ccadmin.sh create --username alice --password pw
+
+# Promouvoir
+bash scripts/bash/ccadmin.sh promote --username alice
+
+# Reset password
+bash scripts/bash/ccadmin.sh reset-password --username alice --new-password newpw


### PR DESCRIPTION
## Summary
- add ccadmin CLI for user list/create/promote/reset-password
- expose console script and wrappers for PowerShell and Bash
- add unit tests for CLI create/promote/list and duplicate user

## Testing
- `python -m ruff check backend`
- `python -m mypy backend/app/cli.py backend/tests/test_cli_admin.py`
- `pytest -q --cov=backend -k "test_cli_admin"`
- `ccadmin list`
- `powershell -File PS1/ccadmin.ps1 -Command list` *(fails: command not found)*
- `powershell -File PS1/ccadmin.ps1 -Command create -Username alice -Password pw` *(fails: command not found)*
- `bash scripts/bash/ccadmin.sh list`
- `bash scripts/bash/ccadmin.sh create --username bob --password pw`


------
https://chatgpt.com/codex/tasks/task_e_68a730bc65c48330b0a6dc38ab9f77af