### PR TITLE
ETAPE 21 - Wrapper Windows (.cmd) pour CLI admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,36 @@ bash scripts/bash/docker_smoke.sh
 
 L'image sert l'API (`/healthz`) et le SPA sur `/` (FRONT_DIST_DIR=/app/public).
 
+### CLI Admin (ccadmin)
+
+#### Windows
+
+```
+win\ccadmin.cmd list
+win\ccadmin.cmd create --username alice --password pw
+win\ccadmin.cmd promote --username alice
+win\ccadmin.cmd reset-password --username alice --new-password newpw
+```
+
+Le wrapper tente `pwsh` puis `powershell`. Si aucun n'est présent, installez PowerShell 7:
+
+```powershell
+powershell -File .\PS1\install_pwsh_on_windows.ps1
+```
+
+#### Linux/mac
+
+```
+bash scripts/bash/ccadmin.sh list
+bash scripts/bash/ccadmin.sh create --username bob --password pw
+```
+
+OU via entrypoint Python si installé:
+
+```
+ccadmin list
+```
+
 ## Back-end (FastAPI)
 
 Base URL: `http://localhost:8001`

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -49,7 +49,7 @@ def cmd_promote(args: argparse.Namespace) -> int:
         if not u:
             _json_out({"error": "Utilisateur introuvable"})
             return ERR
-        u.role = "admin"  # type: ignore[attr-defined]
+        u.role = "admin"
         db.add(u)
         _json_out({"promoted": {"username": u.username, "role": "admin"}})
     return OK

--- a/win/ccadmin.cmd
+++ b/win/ccadmin.cmd
@@ -1,0 +1,16 @@
+@echo off
+REM Lanceur Windows pour la CLI admin. Essaye d'abord PowerShell 7 (pwsh), puis Windows PowerShell.
+where pwsh >nul 2>&1
+if %errorlevel%==0 (
+    pwsh -NoLogo -NoProfile -File "%~dp0..\PS1\ccadmin.ps1" -Command %*
+    exit /b %errorlevel%
+)
+where powershell >nul 2>&1
+if %errorlevel%==0 (
+    powershell -NoLogo -NoProfile -File "%~dp0..\PS1\ccadmin.ps1" -Command %*
+    exit /b %errorlevel%
+)
+echo [ERREUR] PowerShell non installe. Alternatives:
+echo   - Linux/mac: bash scripts\bash\ccadmin.sh list
+echo   - Installer PowerShell 7: .\PS1\install_pwsh_on_windows.ps1 (admin)
+exit /b 1


### PR DESCRIPTION
## Summary
- add Windows batch wrapper for ccadmin CLI that falls back from pwsh to powershell
- document cross-platform admin CLI usage in README
- drop unused type ignore in CLI to satisfy mypy

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a734f53e3c8330830b2b260a8fbc91