### PR TITLE
ETAPE 22 - CLI packagée dans Docker + tests CI

### DIFF
--- a/.github/workflows/cli_docker.yml
+++ b/.github/workflows/cli_docker.yml
@@ -1,0 +1,44 @@
+name: CLI in Docker
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "backend/**"
+      - "Dockerfile"
+      - "scripts/bash/docker_ccadmin.sh"
+      - "PS1/docker_ccadmin.ps1"
+      - ".github/workflows/cli_docker.yml"
+  push:
+    branches: [ main ]
+
+jobs:
+  cli-docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image
+        run: docker build -t ccapi:cli-ci .
+      - name: Prepare shared volume
+        run: docker volume create ccapi_cli_ci
+      - name: CLI list (should succeed)
+        run: docker run --rm -e DB_DSN="sqlite:////data/cc.db" -v ccapi_cli_ci:/data ccapi:cli-ci ccadmin list
+      - name: CLI create user (first should succeed)
+        run: |
+          docker run --rm -e DB_DSN="sqlite:////data/cc.db" \
+            -v ccapi_cli_ci:/data ccapi:cli-ci ccadmin create --username ciuser --password pw
+      - name: CLI create duplicate (should fail exit code 1)
+        run: |
+          set +e
+          docker run --rm -e DB_DSN="sqlite:////data/cc.db" \
+            -v ccapi_cli_ci:/data ccapi:cli-ci ccadmin create --username ciuser --password pw
+          rc=$?
+          echo "rc=$rc"
+          test "$rc" -eq 1
+      - name: CLI promote user (should succeed)
+        run: |
+          docker run --rm -e DB_DSN="sqlite:////data/cc.db" \
+            -v ccapi_cli_ci:/data ccapi:cli-ci ccadmin promote --username ciuser
+      - name: Summary
+        run: echo "CLI Docker tests OK" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 # syntax=docker/dockerfile:1.7
 
+# NOTE: ccadmin est deja disponible car `pip install -e backend` installe la console-script.
+# Usage:
+# docker run --rm ccapi:local ccadmin list
+# docker run --rm -e DB_DSN="sqlite:////data/cc.db" -v ccapi_cli_data:/data ccapi:local ccadmin create --username alice --password pw
+
 # Stage 1: build front
 FROM node:20-alpine AS webbuild
 WORKDIR /web

--- a/PS1/docker_ccadmin.ps1
+++ b/PS1/docker_ccadmin.ps1
@@ -1,0 +1,42 @@
+$ErrorActionPreference = "Stop"
+param(
+    [Parameter(Mandatory=$true)][ValidateSet("list","create","promote","reset-password")] [string]$Command,
+    [string]$Username,
+    [string]$Password,
+    [string]$Role = "user",
+    [string]$NewPassword,
+    [string]$Image = "ccapi:local",
+    [string]$Volume = "ccapi_cli_data"
+)
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Error "Docker non installe. Installez Docker Desktop ou utilisez les scripts Bash locaux."
+    exit 1
+}
+
+# Build si l image n existe pas
+
+$exists = (docker images -q $Image)
+if (-not $exists) {
+    Write-Host "Image $Image absente. Construction..." -ForegroundColor Yellow
+    docker build -t $Image .
+}
+
+# Volume persistant pour la DB
+
+docker volume create $Volume | Out-Null
+
+# Construire la ligne de commande ccadmin
+
+$baseArgs = @("run","--rm","-e","DB_DSN=sqlite:////data/cc.db","-v","$Volume:/data",$Image,"ccadmin")
+switch ($Command) {
+    "list"           { $args = $baseArgs + @("list") }
+    "create"         { $args = $baseArgs + @("create","--username",$Username,"--password",$Password,"--role",$Role) }
+    "promote"        { $args = $baseArgs + @("promote","--username",$Username) }
+    "reset-password" { $args = $baseArgs + @("reset-password","--username",$Username,"--new-password",$NewPassword) }
+}
+
+# Executer
+
+$proc = Start-Process docker -ArgumentList $args -NoNewWindow -PassThru -Wait
+exit $proc.ExitCode

--- a/README.md
+++ b/README.md
@@ -184,6 +184,47 @@ OU via entrypoint Python si installé:
 ccadmin list
 ```
 
+### CLI Admin via Docker
+
+Sans Python local:
+
+```
+# Linux/mac
+bash scripts/bash/docker_ccadmin.sh list
+bash scripts/bash/docker_ccadmin.sh create --username alice --password pw
+bash scripts/bash/docker_ccadmin.sh promote --username alice
+bash scripts/bash/docker_ccadmin.sh reset-password --username alice --new-password newpw
+```
+
+Persistance DB entre commandes dans un volume: `ccapi_cli_data`.
+Équivalent brut:
+
+```
+docker run --rm -e DB_DSN="sqlite:////data/cc.db" -v ccapi_cli_data:/data ccapi:local ccadmin list
+```
+
+Windows (PowerShell):
+
+```
+./PS1/docker_ccadmin.ps1 -Command list
+./PS1/docker_ccadmin.ps1 -Command create -Username alice -Password pw
+```
+
+#### Tests (PowerShell + Bash)
+
+```
+# Linux/mac
+bash scripts/bash/docker_ccadmin.sh list
+bash scripts/bash/docker_ccadmin.sh create --username alice --password pw
+bash scripts/bash/docker_ccadmin.sh create --username alice --password pw && echo "DOIT ECHOUER" || echo "OK (exit 1 attendu)"
+bash scripts/bash/docker_ccadmin.sh promote --username alice
+
+# Windows
+powershell -File PS1/docker_ccadmin.ps1 -Command list
+powershell -File PS1/docker_ccadmin.ps1 -Command create -Username alice -Password pw
+powershell -File PS1/docker_ccadmin.ps1 -Command promote -Username alice
+```
+
 ## Back-end (FastAPI)
 
 Base URL: `http://localhost:8001`

--- a/scripts/bash/docker_ccadmin.sh
+++ b/scripts/bash/docker_ccadmin.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IMAGE="${IMAGE:-ccapi:local}"
+VOLUME="${VOLUME:-ccapi_cli_data}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker non installe. Installez Docker ou utilisez 'bash scripts/bash/ccadmin.sh' (Python local requis)." >&2
+  exit 1
+fi
+
+CMD="${1:-}"; shift || true
+[ -n "$CMD" ] || { echo "Usage: $0 <list|create|promote|reset-password> [args]"; exit 1; }
+
+# Build si image absente
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "Image $IMAGE absente. Construction..."
+  docker build -t "$IMAGE" .
+fi
+
+docker volume create "$VOLUME" >/dev/null
+
+BASE_RUN=(docker run --rm -e DB_DSN="sqlite:////data/cc.db" -v "${VOLUME}:/data" "$IMAGE" ccadmin)
+
+case "$CMD" in
+  list)
+    "${BASE_RUN[@]}" list
+    ;;
+  create)
+    # --username --password [--role]
+    "${BASE_RUN[@]}" create "$@"
+    ;;
+  promote)
+    # --username
+    "${BASE_RUN[@]}" promote "$@"
+    ;;
+  reset-password)
+    # --username --new-password
+    "${BASE_RUN[@]}" reset-password "$@"
+    ;;
+  *)
+    echo "Commande inconnue: $CMD" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add Docker helpers for ccadmin (bash & PowerShell)
- document Docker usage and persistence for ccadmin
- add GitHub workflow to test ccadmin inside Docker

## Testing
- `bash scripts/bash/docker_ccadmin.sh create --username alice --password pw` *(fails: Docker non installe)*
- `PYTHONPATH=backend pytest -q`



------
https://chatgpt.com/codex/tasks/task_e_68a73a700eb88330be82ae7a15ee1280