### PR TITLE
ETAPE 24 - Exclure tests de la couverture + Politique de warnings Pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+# Mesurer uniquement le code applicatif; ignorer les tests.
+source = backend
+omit =
+    backend/tests/*
+    */__init__.py
+
+[report]
+show_missing = True
+skip_covered = True
+
+# Ne pas imposer de seuil ici pour ne pas casser la CI tant que la policy est recente.
+# fail_under = 90

--- a/README.md
+++ b/README.md
@@ -386,6 +386,23 @@ bash scripts/bash/compose_down_postgres.sh
 - Lint/Test Web : `npm run lint`, `npm test` dans `web/`
 - Smoke : voir [Scripts utiles](#scripts-utiles)
 
+### Couverture & Warnings (Pytest)
+
+* La couverture reporte maintenant UNIQUEMENT le code applicatif (`backend/app/**`, etc.) grâce à `.coveragerc`.
+* Les fichiers de tests sont exclus du calcul (plus de % bas sur `backend/tests/**`).
+* Les warnings des libs (SQLAlchemy, Pydantic...) sont filtrés via `pytest.ini`.
+  Pour voir tous les warnings:
+
+  ```
+  pytest -W default::Warning -ra
+  ```
+
+  Pour un rapport de couverture détaillé des lignes manquantes:
+
+  ```
+  pytest -q --cov=backend --cov-report=term-missing
+  ```
+
 ## Observabilité
 
 - Header `X-Request-ID` (propagation auto)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,19 @@
+[pytest]
+addopts = -ra
+testpaths = backend/tests
+
+filterwarnings =
+    # Garder les warnings applicatifs (app.*) visibles
+    default:.*:DeprecationWarning:app\..*
+    default:.*:FutureWarning:app\..*
+    # Reduire le bruit des dependances frequentes
+    ignore::DeprecationWarning:pydantic\..*
+    ignore::DeprecationWarning:sqlalchemy\..*
+    ignore::DeprecationWarning:asyncio\..*
+    ignore::DeprecationWarning:jinja2\..*
+    ignore::DeprecationWarning:pkg_resources\..*
+    ignore::PendingDeprecationWarning
+    ignore::FutureWarning
+
+# Optionnel: desactiver les warnings de ressources bruitants
+# disable_test_id_escaping_and_forfeit_all_rights_to_community_support = True


### PR DESCRIPTION
## Summary
- limit coverage measurement to application code via `.coveragerc`
- filter noisy third-party warnings and keep app warnings visible with `pytest.ini`
- document new coverage and warning policy in README

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `PYTHONPATH=backend pytest -q --cov=backend`
- `PYTHONPATH=backend pytest -q --cov=backend --cov-report=term-missing`
- `PYTHONPATH=backend pytest -W default::Warning -ra`

Labels: tests, quality
Assignees: @owner

------
https://chatgpt.com/codex/tasks/task_e_68a742ab9fe88330b76d29cf4e4123dc