### PR TITLE
ETAPE 25 - Fail-under 90 + warnings app en erreurs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,4 @@ omit =
 [report]
 show_missing = True
 skip_covered = True
-
-# Ne pas imposer de seuil ici pour ne pas casser la CI tant que la policy est recente.
-# fail_under = 90
+fail_under = 90

--- a/README.md
+++ b/README.md
@@ -386,22 +386,41 @@ bash scripts/bash/compose_down_postgres.sh
 - Lint/Test Web : `npm run lint`, `npm test` dans `web/`
 - Smoke : voir [Scripts utiles](#scripts-utiles)
 
-### Couverture & Warnings (Pytest)
+### Seuil de couverture et politique des warnings
 
-* La couverture reporte maintenant UNIQUEMENT le code applicatif (`backend/app/**`, etc.) grâce à `.coveragerc`.
-* Les fichiers de tests sont exclus du calcul (plus de % bas sur `backend/tests/**`).
-* Les warnings des libs (SQLAlchemy, Pydantic...) sont filtrés via `pytest.ini`.
-  Pour voir tous les warnings:
-
-  ```
-  pytest -W default::Warning -ra
-  ```
-
-  Pour un rapport de couverture détaillé des lignes manquantes:
+* Couverture minimale imposée: `fail_under = 90` (uniquement code applicatif).
+* Les `DeprecationWarning`/`FutureWarning` provenant de `app.*` échouent les tests (anticipation des maj).
+* Pour afficher tous les warnings (diagnostic):
 
   ```
-  pytest -q --cov=backend --cov-report=term-missing
+  PYTHONPATH=backend pytest -W default::Warning -ra
   ```
+
+* Pour un rapport de couverture détaillé:
+
+  ```
+  PYTHONPATH=backend pytest -q --cov=backend --cov-report=term-missing
+  ```
+
+### Scripts PowerShell/tests rapides
+
+```powershell
+powershell -NoLogo -NoProfile -Command "python -m ruff check backend; python -m mypy backend; $env:PYTHONPATH='backend'; pytest -q --cov=backend"
+
+# Diagnostic warnings complet (optionnel)
+powershell -NoLogo -NoProfile -Command "$env:PYTHONPATH='backend'; pytest -W default::Warning -ra"
+```
+
+### Scripts Bash/tests rapides
+
+```bash
+PYTHONPATH=backend python -m ruff check backend
+PYTHONPATH=backend python -m mypy backend
+PYTHONPATH=backend pytest -q --cov=backend
+
+# Diagnostic warnings (optionnel)
+PYTHONPATH=backend pytest -W default::Warning -ra
+```
 
 ## Observabilité
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,19 +1,24 @@
 [pytest]
-addopts = -ra
+addopts = -ra --maxfail=1
 testpaths = backend/tests
 
+# Politique de warnings:
+#
+# - Les warnings issus de NOTRE code sont traités en erreur.
+# - On ignore le bruit connu des libs tierces.
+
 filterwarnings =
-    # Garder les warnings applicatifs (app.*) visibles
-    default:.*:DeprecationWarning:app\..*
-    default:.*:FutureWarning:app\..*
-    # Reduire le bruit des dependances frequentes
+    error:.*:DeprecationWarning:app\..*
+    error:.*:FutureWarning:app\..*
+    default:.*:DeprecationWarning
+    default:.*:FutureWarning
+
     ignore::DeprecationWarning:pydantic\..*
+    ignore::FutureWarning:pydantic\..*
     ignore::DeprecationWarning:sqlalchemy\..*
-    ignore::DeprecationWarning:asyncio\..*
+    ignore::sqlalchemy.exc.SAWarning
     ignore::DeprecationWarning:jinja2\..*
     ignore::DeprecationWarning:pkg_resources\..*
     ignore::PendingDeprecationWarning
-    ignore::FutureWarning
+    ignore::ResourceWarning
 
-# Optionnel: desactiver les warnings de ressources bruitants
-# disable_test_id_escaping_and_forfeit_all_rights_to_community_support = True


### PR DESCRIPTION
## Summary
- enforce 90% coverage gate in `.coveragerc`
- tighten pytest warning policy: app Deprecation/Future warnings fail, deps silenced
- document coverage threshold, warning policy and quick test scripts in README

## Testing
- `PYTHONPATH=backend python -m ruff check backend`
- `PYTHONPATH=backend python -m mypy backend`
- `PYTHONPATH=backend pytest -q --cov=backend`
- `PYTHONPATH=backend pytest -W default::Warning -ra`

------
https://chatgpt.com/codex/tasks/task_e_68a749d505848330a043e94c9e4a4a28