### PR TITLE
Fix CI (cli-docker, migrations, observability)

### DIFF
--- a/.github/workflows/cli_docker.yml
+++ b/.github/workflows/cli_docker.yml
@@ -40,5 +40,9 @@ jobs:
         run: |
           docker run --rm -e DB_DSN="sqlite:////data/cc.db" \
             -v ccapi_cli_ci:/data ccapi:cli-ci ccadmin promote --username ciuser
-      - name: Summary
-        run: echo "CLI Docker tests OK" >> $GITHUB_STEP_SUMMARY
+      - name: Debug info on failure
+        if: failure()
+        run: |
+          docker images
+          docker volume ls
+          echo "No compose logs to show for CLI job."

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -22,8 +22,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e backend[dev]
       - name: Alembic upgrade head (SQLite)
-        run: |
-          PYTHONPATH=backend alembic upgrade head
+        run: PYTHONPATH=backend alembic upgrade head
       - name: Pytests migrations smoke
+        run: PYTHONPATH=backend pytest -q -k "migrations_smoke"
+      - name: Env debug (on failure)
+        if: failure()
         run: |
-          PYTHONPATH=backend pytest -q -k "migrations_smoke"
+          python --version
+          pip list

--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -19,18 +19,29 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - name: Compose up
         run: docker compose -f docker-compose.observability.yml up -d --build
-      - name: Wait backend
+      - name: Wait backend health (compose healthcheck)
         run: |
           for i in $(seq 1 60); do
+            st=$(docker inspect --format='{{json .State.Health.Status}}' $(docker ps -q --filter "name=_backend_1") 2>/dev/null || echo '"starting"')
+            echo "backend health: $st"
+            [ "$st" = '"healthy"' ] && break
+            sleep 2
+          done
+      - name: Ensure /healthz responds 200
+        run: |
+          for i in $(seq 1 30); do
             code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8001/healthz || true)
             [ "$code" = "200" ] && break
             sleep 1
           done
-          [ "${code:-0}" = "200" ] || (docker compose -f docker-compose.observability.yml logs --no-color && exit 1)
+          [ "${code:-0}" = "200" ]
       - name: Prometheus targets include ccapi
         run: |
           curl -fsS http://localhost:9090/-/ready >/dev/null
           curl -fsS http://localhost:9090/api/v1/targets | grep -q '"job":"ccapi"'
+      - name: Compose logs (on failure)
+        if: failure()
+        run: docker compose -f docker-compose.observability.yml logs --no-color
       - name: Compose down
         if: always()
         run: docker compose -f docker-compose.observability.yml down -v

--- a/backend/tests/test_observability_compose.py
+++ b/backend/tests/test_observability_compose.py
@@ -1,0 +1,6 @@
+import pathlib
+
+def test_backend_healthcheck_uses_python():
+    compose = pathlib.Path(__file__).resolve().parents[2] / "docker-compose.observability.yml"
+    text = compose.read_text()
+    assert "python - <<'PY'" in text

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -9,7 +9,8 @@ services:
     ports:
       - "8001:8001"
     healthcheck:
-      test: ["CMD","curl","-fsS","http://localhost:8001/healthz"]
+      # Avoid curl/wget dependency; use Python available in image
+      test: ["CMD-SHELL","python - <<'PY'\nimport sys,urllib.request\ntry:\n  with urllib.request.urlopen('http://localhost:8001/healthz', timeout=2) as r:\n    sys.exit(0 if r.status==200 else 1)\nexcept Exception:\n  sys.exit(1)\nPY"]
       interval: 5s
       timeout: 3s
       retries: 20


### PR DESCRIPTION
## Summary
- remove curl dependency for observability healthcheck
- harden workflows with PYTHONPATH and debug logs
- add regression test for backend healthcheck

## Testing
- `grep -n "python - <<'PY'" docker-compose.observability.yml`
- `PYTHONPATH=backend alembic upgrade head`
- `PYTHONPATH=backend pytest backend/tests/test_observability_compose.py -q`
- `PYTHONPATH=backend pytest -q -k "migrations_smoke"`


------
https://chatgpt.com/codex/tasks/task_e_68a764f4c7588330a48d633e5072a21f