### PR TITLE
ETAPE 32 - Export OpenAPI offline + scripts + CI artefact

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,34 @@
+name: OpenAPI Export
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "backend/**"
+      - "scripts/bash/export_openapi.sh"
+      - "PS1/export_openapi.ps1"
+      - ".github/workflows/openapi.yml"
+  push:
+    branches: [ main ]
+
+jobs:
+  export-openapi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11", cache: "pip" }
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e backend[dev]
+      - name: Run unit tests (OpenAPI)
+        run: |
+          PYTHONPATH=backend pytest -q -k "openapi_export"
+      - name: Export OpenAPI
+        run: |
+          PYTHONPATH=backend bash scripts/bash/export_openapi.sh docs openapi.json
+      - name: Upload openapi.json
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi
+          path: docs/openapi.json

--- a/PS1/export_openapi.ps1
+++ b/PS1/export_openapi.ps1
@@ -1,0 +1,14 @@
+param(
+    [string]$OutDir = "docs",
+    [string]$OutFile = "openapi.json"
+)
+$ErrorActionPreference = "Stop"
+$env:EXPORT_OPENAPI_DIR = $OutDir
+$env:EXPORT_OPENAPI_FILE = $OutFile
+
+# Assumer PYTHONPATH=backend pour import "app"
+
+if (-not $env:PYTHONPATH) { $env:PYTHONPATH = "backend" }
+Write-Host "Export OpenAPI -> $OutDir$OutFile" -ForegroundColor Cyan
+python -m tools.export_openapi | Out-Null
+Write-Host "OK."

--- a/README.md
+++ b/README.md
@@ -227,6 +227,19 @@ powershell -File PS1/docker_ccadmin.ps1 -Command create -Username alice -Passwor
 powershell -File PS1/docker_ccadmin.ps1 -Command promote -Username alice
 ```
 
+### Export OpenAPI (offline)
+
+Generer `docs/openapi.json` sans demarrer le serveur:
+
+```
+# Windows
+powershell -File PS1/export_openapi.ps1 -OutDir docs -OutFile openapi.json
+# Bash
+bash scripts/bash/export_openapi.sh docs openapi.json
+```
+
+CI `OpenAPI Export` construit et uploade l artefact.
+
 ## Back-end (FastAPI)
 
 Base URL: `http://localhost:8001`
@@ -360,6 +373,7 @@ Jobs :
 - `compose_smoke` (docker compose + healthz)
 - `postgres_tests` (service Postgres, alembic upgrade, tests)
 - `frontend` (npm ci, lint, test, build, smoke ETag cross-OS)
+- `openapi` (export openapi.json et artefact)
 
 ## Releases
 

--- a/backend/tests/test_openapi_export.py
+++ b/backend/tests/test_openapi_export.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from tools.export_openapi import main as export_main
+
+
+def test_openapi_endpoint_ok() -> None:
+    app = create_app()
+    c = TestClient(app)
+    r = c.get("/openapi.json")
+    assert r.status_code == 200
+    data = r.json()
+    assert "openapi" in data
+    assert "info" in data and "title" in data["info"] and "version" in data["info"]
+
+
+def test_openapi_export_offline_writes_file(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("EXPORT_OPENAPI_DIR", str(tmp_path))
+    monkeypatch.setenv("EXPORT_OPENAPI_FILE", "schema.json")
+    # s assurer d un PYTHONPATH correct en environnement de test
+    monkeypatch.setenv("PYTHONPATH", "backend")
+    rc = export_main()
+    assert rc == 0
+    p = tmp_path / "schema.json"
+    assert p.exists()
+    data = json.loads(p.read_text(encoding="utf-8"))
+    assert "openapi" in data and isinstance(data["openapi"], str)

--- a/backend/tools/export_openapi.py
+++ b/backend/tools/export_openapi.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+
+def main() -> int:
+    # Permettre la configuration simple de la sortie
+    out_dir = Path(os.getenv("EXPORT_OPENAPI_DIR", "docs")).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / os.getenv("EXPORT_OPENAPI_FILE", "openapi.json")
+
+    # Import paresseux pour eviter effets secondaires si non necessaire
+    from app.main import create_app
+
+    app = create_app()
+    spec = app.openapi()
+    # Versionner proprement
+    # FastAPI ajoute deja info.version; on s assure d avoir title
+    if "info" not in spec:
+        spec["info"] = {"title": "API", "version": "0.0.0"}
+
+    out_file.write_text(
+        json.dumps(spec, ensure_ascii=True, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    print(str(out_file))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bash/export_openapi.sh
+++ b/scripts/bash/export_openapi.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+OUT_DIR="${1:-docs}"
+OUT_FILE="${2:-openapi.json}"
+export EXPORT_OPENAPI_DIR="${OUT_DIR}"
+export EXPORT_OPENAPI_FILE="${OUT_FILE}"
+export PYTHONPATH="${PYTHONPATH:-backend}"
+python -m tools.export_openapi >/dev/null
+echo "OpenAPI ecrit dans ${OUT_DIR}/${OUT_FILE}"


### PR DESCRIPTION
## Summary
- add offline OpenAPI exporter and helper scripts for Windows and Bash
- test OpenAPI endpoint and export
- add workflow exporting schema as artifact

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `PYTHONPATH=backend pytest -q -k "openapi_export"`
- `PYTHONPATH=backend bash scripts/bash/export_openapi.sh`
- `PYTHONPATH=backend python -m tools.export_openapi`
- `pwsh -NoLogo -NoProfile -Command "Write-Host test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a766cb45dc833090314d621f084abe