### PR TITLE
ETAPE 33 - Backup/Restore DB (SQLite natif, PG optionnel) + scripts + tests

### DIFF
--- a/PS1/db_backup.ps1
+++ b/PS1/db_backup.ps1
@@ -1,0 +1,9 @@
+param(
+    [string]$Dsn = $env:DB_DSN,
+    [Parameter(Mandatory=$true)][string]$Out
+)
+$ErrorActionPreference = "Stop"
+if (-not $env:PYTHONPATH) { $env:PYTHONPATH = "backend" }
+Write-Host "Backup DB -> $Out" -ForegroundColor Cyan
+python -m tools.backup_restore backup --dsn $Dsn --out $Out
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/PS1/db_restore.ps1
+++ b/PS1/db_restore.ps1
@@ -1,0 +1,12 @@
+param(
+    [string]$Dsn = $env:DB_DSN,
+    [Parameter(Mandatory=$true)][string]$In,
+    [switch]$Overwrite
+)
+$ErrorActionPreference = "Stop"
+if (-not $env:PYTHONPATH) { $env:PYTHONPATH = "backend" }
+$ow = @()
+if ($Overwrite) { $ow = @("--overwrite") }
+Write-Host "Restore DB <- $In" -ForegroundColor Yellow
+python -m tools.backup_restore restore --dsn $Dsn --in $In @ow
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/README.md
+++ b/README.md
@@ -564,6 +564,32 @@ HSTS_PRELOAD=false
 - **pwsh introuvable** : sur Windows utiliser `powershell.exe`; en CI fallback bash implémenté.
 - **Docker indisponible sur runner** : le job `compose_smoke` se termine proprement en no-op.
 
+### Sauvegarde / Restore DB
+
+Par defaut, DSN: `DB_DSN` (sinon `sqlite:///./cc.db`).
+
+SQLite:
+
+```
+# Windows
+powershell -File PS1\db_backup.ps1 -Out backups\cc.sqlite
+powershell -File PS1\db_restore.ps1 -In backups\cc.sqlite -Overwrite
+
+# Bash
+bash scripts/bash/db_backup.sh backups/cc.sqlite
+bash scripts/bash/db_restore.sh backups/cc.sqlite --overwrite
+```
+
+Postgres (optionnel, si `pg_dump` / `psql` / `pg_restore` installes):
+
+```
+# Exemple DSN
+$env:DB_DSN="postgresql+psycopg://cc:cc@localhost:5432/ccdb"
+powershell -File PS1\db_backup.ps1 -Out backups\cc.pg.dump
+powershell -File PS1\db_restore.ps1 -In backups\cc.pg.dump
+```
+
+En absence des outils, un message clair est renvoye.
 ## Roadmap / Étapes livrées
 
 1. Setup backend de base

--- a/backend/tests/test_backup_restore_sqlite.py
+++ b/backend/tests/test_backup_restore_sqlite.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tools.backup_restore import backup, restore
+
+
+def _prepare_sqlite_db(tmp_path: Path) -> str:
+    db = tmp_path / "db.sqlite"
+    dsn = f"sqlite:///{db}"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+        conn.execute("INSERT INTO t (name) VALUES ('alice'), ('bob')")
+        conn.commit()
+    return dsn
+
+
+def test_backup_and_restore_sqlite_ok(tmp_path: Path) -> None:
+    dsn = _prepare_sqlite_db(tmp_path)
+    dump = tmp_path / "dump.sqlite"
+    backup(dsn, dump)
+    assert dump.exists() and dump.stat().st_size > 0
+    dsn_target = f"sqlite:///{tmp_path/'db_restored.sqlite'}"
+    restore(dsn_target, dump, overwrite=True)
+    with sqlite3.connect(tmp_path / "db_restored.sqlite") as conn:
+        rows = list(conn.execute("SELECT COUNT(*) FROM t"))
+        assert rows[0][0] == 2
+
+
+def test_restore_sqlite_invalid_dump_ko(tmp_path: Path) -> None:
+    dsn = _prepare_sqlite_db(tmp_path)
+    bad = tmp_path / "bad.dump"
+    bad.write_text("NOT A SQLITE FILE", encoding="utf-8")
+    with pytest.raises(Exception):
+        restore(dsn, bad, overwrite=True)

--- a/backend/tools/backup_restore.py
+++ b/backend/tools/backup_restore.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+def _resolve_dsn(dsn: Optional[str]) -> str:
+    return dsn if dsn is not None else os.getenv("DB_DSN", "sqlite:///./cc.db")
+
+
+def _is_sqlite(dsn: str) -> bool:
+    return dsn.startswith("sqlite:///")
+
+
+def _sqlite_path(dsn: str) -> Path:
+    p = dsn.removeprefix("sqlite:///")
+    return Path(p).resolve()
+
+
+def backup(dsn: Optional[str], out_file: Path) -> None:
+    """
+    Sauvegarde la base au chemin out_file.
+    - SQLite: utilise backup API atomique.
+    - Postgres: utilise pg_dump si dispo.
+    """
+    dsnv = _resolve_dsn(dsn)
+    out_file = out_file.resolve()
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+
+    if _is_sqlite(dsnv):
+        db_path = _sqlite_path(dsnv)
+        if not db_path.exists():
+            raise FileNotFoundError(f"Base SQLite introuvable: {db_path}")
+        with sqlite3.connect(db_path) as src, sqlite3.connect(str(out_file)) as dst:
+            src.backup(dst)
+        return
+
+    if dsnv.startswith("postgresql"):
+        if shutil.which("pg_dump") is None:
+            raise RuntimeError(
+                "pg_dump non trouve dans le PATH. Installez les outils Postgres pour utiliser le backup Postgres."
+            )
+        dsn_pg = dsnv.replace("+psycopg", "")
+        cmd = ["pg_dump", dsn_pg, "-Fc", "-f", str(out_file)]
+        subprocess.run(cmd, check=True)
+        return
+
+    raise ValueError(f"DSN non supporte: {dsnv}")
+
+
+def restore(dsn: Optional[str], dump_file: Path, overwrite: bool = False) -> None:
+    """
+    Restore la base depuis dump_file.
+    - SQLite: ecrase le fichier cible (avec option overwrite).
+    - Postgres: via psql/pg_restore si dispo.
+    """
+    dsnv = _resolve_dsn(dsn)
+    dump_file = dump_file.resolve()
+    if not dump_file.exists():
+        raise FileNotFoundError(f"Dump introuvable: {dump_file}")
+
+    if _is_sqlite(dsnv):
+        db_path = _sqlite_path(dsnv)
+        if db_path.exists() and not overwrite:
+            raise FileExistsError(
+                f"Base cible existe deja: {db_path}. Utilisez overwrite=True pour ecraser."
+            )
+        with open(dump_file, "rb") as fh:
+            header = fh.read(16)
+        if header != b"SQLite format 3\x00":
+            raise ValueError(f"Dump SQLite invalide: {dump_file}")
+        shutil.copy2(dump_file, db_path)
+        return
+
+    if dsnv.startswith("postgresql"):
+        if shutil.which("pg_restore") is None or shutil.which("psql") is None:
+            raise RuntimeError(
+                "pg_restore/psql non trouves dans le PATH. Installez les outils Postgres pour utiliser le restore Postgres."
+            )
+        dsn_pg = dsnv.replace("+psycopg", "")
+        subprocess.run(
+            [
+                "psql",
+                dsn_pg,
+                "-c",
+                "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;",
+            ],
+            check=True,
+        )
+        subprocess.run(["pg_restore", "-d", dsn_pg, str(dump_file)], check=True)
+        return
+
+    raise ValueError(f"DSN non supporte: {dsnv}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(
+        prog="ccdb", description="Sauvegarde/Restore DB (SQLite natif; Postgres optionnel)"
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    b = sub.add_parser("backup", help="Creer un dump")
+    b.add_argument("--dsn", default=None, help="DB_DSN; par defaut $DB_DSN ou sqlite:///./cc.db")
+    b.add_argument("--out", required=True, help="Chemin du fichier dump (sera cree)")
+
+    r = sub.add_parser("restore", help="Restaurer depuis un dump")
+    r.add_argument("--dsn", default=None)
+    r.add_argument("--in", dest="in_file", required=True, help="Chemin du dump a restaurer")
+    r.add_argument("--overwrite", action="store_true", help="Ecraser la base cible si elle existe (SQLite)")
+
+    args = p.parse_args(argv)
+    try:
+        if args.cmd == "backup":
+            backup(args.dsn, Path(args.out))
+        elif args.cmd == "restore":
+            restore(args.dsn, Path(args.in_file), overwrite=args.overwrite)
+        print("OK")
+        return 0
+    except Exception as e:
+        print(f"ERREUR: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    import sys
+
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/bash/db_backup.sh
+++ b/scripts/bash/db_backup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DSN="${DB_DSN:-sqlite:///./cc.db}"
+OUT="${1:?Usage: $0 <out_file>}"
+export PYTHONPATH="${PYTHONPATH:-backend}"
+python -m tools.backup_restore backup --dsn "$DSN" --out "$OUT"

--- a/scripts/bash/db_restore.sh
+++ b/scripts/bash/db_restore.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DSN="${DB_DSN:-sqlite:///./cc.db}"
+IN="${1:?Usage: $0 <dump_file>}"
+OW="${2:-}"
+export PYTHONPATH="${PYTHONPATH:-backend}"
+args=(restore --dsn "$DSN" --in "$IN")
+[ "$OW" = "--overwrite" ] && args+=("--overwrite")
+python -m tools.backup_restore "${args[@]}"


### PR DESCRIPTION
## Summary
- add atomic SQLite and optional Postgres backup/restore tooling
- provide Windows PowerShell and Bash scripts for database backup and restore
- document usage in README

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `PYTHONPATH=backend pytest -q --cov=backend -k "backup_restore_sqlite" --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68a76aa528888330a0157540337fe1de