### PR TITLE
ETAPE 33-FIX - Stabiliser CI (CLI Docker + Observability)

### DIFF
--- a/.github/workflows/cli_docker.yml
+++ b/.github/workflows/cli_docker.yml
@@ -19,10 +19,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
       - name: Build image
-        run: docker build -t ccapi:cli-ci .
+        run: docker build --pull -t ccapi:cli-ci .
       - name: Sanity - ccadmin present
         run: |
-          docker run --rm ccapi:cli-ci sh -lc 'which ccadmin && ccadmin --help || (python -m app.cli --help && exit 0)'
+          set -eux
+          docker run --rm ccapi:cli-ci sh -lc 'echo PATH=$PATH; which ccadmin || true; ccadmin --help || (python -m app.cli --help && exit 0)'
+          docker run --rm ccapi:cli-ci sh -lc 'ccadmin --version || python -m app.cli --version || true'
       - name: Prepare shared volume
         run: docker volume create ccapi_cli_ci
       - name: CLI list (should succeed)
@@ -34,14 +36,16 @@ jobs:
           set +e
           docker run --rm -e DB_DSN="sqlite:////data/cc.db" -v ccapi_cli_ci:/data ccapi:cli-ci ccadmin create --username ciuser --password pw
           rc=$?
-          echo "rc=$rc"
+          echo "duplicate rc=$rc"
           test "$rc" -eq 1
       - name: CLI promote user (should succeed)
         run: docker run --rm -e DB_DSN="sqlite:////data/cc.db" -v ccapi_cli_ci:/data ccapi:cli-ci ccadmin promote --username ciuser
       - name: Debug info on failure
         if: failure()
         run: |
-          echo "=== docker images ==="
-          docker images
+          set +e
+          echo "=== docker images ==="; docker images
           echo "=== try python -m app.cli --help in image ==="
           docker run --rm ccapi:cli-ci python -m app.cli --help || true
+          echo "=== try list with high verbosity ==="
+          docker run --rm -e DB_DSN="sqlite:////data/cc.db" -v ccapi_cli_ci:/data ccapi:cli-ci sh -lc 'ccadmin list || python -m app.cli list || true'

--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -10,10 +10,11 @@ on:
       - "PS1/observability_*"
       - "scripts/bash/observability_*"
       - ".github/workflows/observability.yml"
+
 jobs:
   obs-smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -21,24 +22,32 @@ jobs:
         run: docker compose -f docker-compose.observability.yml up -d --build
       - name: Wait backend health (compose healthcheck)
         run: |
-          for i in $(seq 1 60); do
-            st=$(docker inspect --format='{{json .State.Health.Status}}' $(docker ps -q --filter "name=_backend_1") 2>/dev/null || echo '"starting"')
+          for i in $(seq 1 90); do
+            id=$(docker ps -q --filter "name=_backend_1")
+            st=$(docker inspect --format='{{.State.Health.Status}}' "$id" 2>/dev/null || echo "starting")
             echo "backend health: $st"
-            [ "$st" = '"healthy"' ] && break
+            [ "$st" = "healthy" ] && break
             sleep 2
           done
+          test "$st" = "healthy"
       - name: Ensure /healthz responds 200
         run: |
           for i in $(seq 1 30); do
             code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8001/healthz || true)
+            echo "probe /healthz -> $code"
             [ "$code" = "200" ] && break
             sleep 1
           done
           [ "${code:-0}" = "200" ]
-      - name: Prometheus targets include ccapi
+      - name: Prometheus targets include ccapi (with retries)
         run: |
-          curl -fsS http://localhost:9090/-/ready >/dev/null
-          curl -fsS http://localhost:9090/api/v1/targets | grep -q '"job":"ccapi"'
+          for i in $(seq 1 30); do
+            curl -fsS http://localhost:9090/-/ready >/dev/null || true
+            body=$(curl -fsS http://localhost:9090/api/v1/targets || true)
+            echo "$body" | grep -q '"job":"ccapi"' && exit 0
+            echo "target ccapi not found yet, retry $i"; sleep 2
+          done
+          echo "ccapi target missing"; exit 1
       - name: Compose logs (on failure)
         if: failure()
         run: docker compose -f docker-compose.observability.yml logs --no-color

--- a/README.md
+++ b/README.md
@@ -375,6 +375,32 @@ Jobs :
 - `frontend` (npm ci, lint, test, build, smoke ETag cross-OS)
 - `openapi` (export openapi.json et artefact)
 
+## CI Stabilisation (CLI Docker & Observability)
+
+Les jobs CI ont ete renforces avec des retries et des logs detaillees en cas d echec.
+
+Observability utilise des versions pinnees: Prometheus v2.53.1, Grafana 11.2.0 pour eviter les surprises.
+
+Les cibles Prometheus sont verifiees avec retries jusqu a 90s pour couvrir les lenteurs reseau du runner.
+
+Scripts/Commandes de repro (si Docker dispo):
+
+```bash
+docker build -t ccapi:cli-ci .
+docker run --rm ccapi:cli-ci sh -lc "which ccadmin || true; ccadmin --help || python -m app.cli --help"
+docker volume create ccapi_cli_ci
+docker run --rm -e DB_DSN="sqlite:////data/cc.db" -v ccapi_cli_ci:/data ccapi:cli-ci ccadmin list
+docker compose -f docker-compose.observability.yml up -d --build
+```
+
+Tests (PowerShell + Bash):
+
+```bash
+python -m ruff check backend
+python -m mypy backend
+PYTHONPATH=backend pytest -q --cov=backend -k "ci_smoke_guards"
+```
+
 ## Releases
 
 ### Tagger une version (Windows)

--- a/backend/tests/test_ci_smoke_guards.py
+++ b/backend/tests/test_ci_smoke_guards.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import pathlib
+
+
+def test_ci_scripts_exist_for_observability_and_cli() -> None:
+    for p in [
+        ".github/workflows/cli_docker.yml",
+        ".github/workflows/observability.yml",
+        "docker-compose.observability.yml",
+    ]:
+        assert pathlib.Path(p).exists()

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -13,10 +13,10 @@ services:
       test: ["CMD-SHELL","python - <<'PY'\nimport sys,urllib.request\ntry:\n  with urllib.request.urlopen('http://localhost:8001/healthz', timeout=2) as r:\n    sys.exit(0 if r.status==200 else 1)\nexcept Exception:\n  sys.exit(1)\nPY"]
       interval: 5s
       timeout: 3s
-      retries: 20
+      retries: 30
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.53.1
     depends_on:
       backend:
         condition: service_healthy
@@ -28,7 +28,7 @@ services:
       - --config.file=/etc/prometheus/prometheus.yml
 
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:11.2.0
     depends_on:
       prometheus:
         condition: service_started


### PR DESCRIPTION
## Summary
- harden cli docker workflow for more diagnostics
- pin observability images and add retries
- guard ci scripts with regression test and docs

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `PYTHONPATH=backend pytest -q --cov=backend -k "ci_smoke_guards"` *(fails: Required test coverage of 90.0% not reached)*
- `PYTHONPATH=backend pytest -q --cov=backend` *(fails: Required test coverage of 90.0% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68a7702143f08330b8f976507a0faa63