### PR TITLE
ETAPE 34 - Securite CI (pip-audit + Trivy) + SARIF

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,46 @@
+name: Security Scans
+on:
+  pull_request:
+    paths:
+      - "backend/**"
+      - "Dockerfile"
+      - "scripts/bash/sec_*"
+      - "PS1/sec_*"
+      - ".github/workflows/security.yml"
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  deps-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: pip-audit (SARIF)
+        run: |
+          bash scripts/bash/sec_pip_audit.sh reports/pip-audit.sarif
+      - name: Upload SARIF (pip-audit)
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: reports/pip-audit.sarif
+
+  image-vuln:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image
+        run: docker build --pull -t ccapi:cli-ci .
+      - name: Trivy image scan (SARIF)
+        run: |
+          bash scripts/bash/sec_trivy_image.sh ccapi:cli-ci reports/trivy.sarif
+      - name: Upload SARIF (trivy)
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: reports/trivy.sarif

--- a/PS1/sec_pip_audit.ps1
+++ b/PS1/sec_pip_audit.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = "Stop"
+param(
+    [string]$Output = "reports\pip-audit.sarif"
+)
+Write-Host "Analyse des dependances Python (pip-audit)..." -ForegroundColor Cyan
+python -m pip install --upgrade pip > $null
+python -m pip install pip-audit cyclonedx-bom > $null
+
+# Installer deps projet (dev) si non deja fait
+python -m pip install -e backend[dev] > $null
+New-Item -ItemType Directory -Force -Path (Split-Path $Output) | Out-Null
+
+# Si un requirements existe, l'auditer silencieusement (ne bloque pas si absent)
+if (Test-Path "backend\requirements.txt") {
+    pip-audit -r backend\requirements.txt | Out-Null
+}
+pip-audit -f sarif -o $Output
+Write-Host "pip-audit OK -> $Output" -ForegroundColor Green

--- a/PS1/sec_trivy_image.ps1
+++ b/PS1/sec_trivy_image.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = "Stop"
+param(
+    [string]$Image = "ccapi:cli-ci",
+    [string]$Output = "reports\trivy.sarif"
+)
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Warning "Docker non installe; on skip le scan d image."
+    exit 0
+}
+New-Item -ItemType Directory -Force -Path (Split-Path $Output) | Out-Null
+if (-not (Get-Command trivy -ErrorAction SilentlyContinue)) {
+    Write-Host "Trivy local non present; utilisation du conteneur aquasec/trivy..." -ForegroundColor Yellow
+    docker pull aquasec/trivy:latest > $null
+    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$PWD:/work" -w /work aquasec/trivy:latest image --severity HIGH,CRITICAL --scanners vuln --format sarif -o $Output $Image
+    exit $LASTEXITCODE
+}
+trivy image --severity HIGH,CRITICAL --scanners vuln --format sarif -o $Output $Image
+Write-Host "Trivy OK -> $Output" -ForegroundColor Green

--- a/README.md
+++ b/README.md
@@ -539,6 +539,18 @@ bash scripts/bash/health_check.sh http://localhost:8001
 - Headers sécurité : `HSTS`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `CSP`, `Permissions-Policy`
 - CORS configurable
 
+### Sécurité CI
+
+* **Deps Python**: `pip-audit` genere un rapport SARIF et echoue sur vuln HIGH/CRITICAL.
+
+  * Windows: `powershell -File PS1\sec_pip_audit.ps1`
+  * Bash: `bash scripts/bash/sec_pip_audit.sh`
+* **Image Docker**: `trivy` scanne l image `ccapi:cli-ci`. Si Docker indisponible localement, le script sort proprement.
+
+  * Windows: `powershell -File PS1\sec_trivy_image.ps1 -Image ccapi:cli-ci`
+  * Bash: `bash scripts/bash/sec_trivy_image.sh ccapi:cli-ci`
+* CI `Security Scans` uploade les rapports dans **Code scanning alerts**.
+
 ### En-tetes de securite
 
 Variables d env:

--- a/backend/tests/test_sec_scripts_exist.py
+++ b/backend/tests/test_sec_scripts_exist.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import stat
+import pathlib
+
+
+def test_sec_scripts_present_and_executable():
+    for p in [
+        "scripts/bash/sec_pip_audit.sh",
+        "scripts/bash/sec_trivy_image.sh",
+    ]:
+        f = pathlib.Path(p)
+        assert f.exists(), f"{p} manquant"
+        mode = f.stat().st_mode
+        assert mode & stat.S_IXUSR, f"{p} non executable"

--- a/scripts/bash/sec_pip_audit.sh
+++ b/scripts/bash/sec_pip_audit.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+OUT="${1:-reports/pip-audit.sarif}"
+mkdir -p "$(dirname "$OUT")"
+python -m pip install --upgrade pip >/dev/null
+python -m pip install pip-audit cyclonedx-bom >/dev/null
+python -m pip install -e backend[dev] >/dev/null
+if [ -f backend/requirements.txt ]; then
+    pip-audit -r backend/requirements.txt >/dev/null || true
+fi
+pip-audit -f sarif -o "$OUT"
+echo "pip-audit OK -> $OUT"

--- a/scripts/bash/sec_trivy_image.sh
+++ b/scripts/bash/sec_trivy_image.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IMAGE="${1:-ccapi:cli-ci}"
+OUT="${2:-reports/trivy.sarif}"
+mkdir -p "$(dirname "$OUT")"
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker non installe; skip du scan image." >&2
+    exit 0
+fi
+if ! command -v trivy >/dev/null 2>&1; then
+    docker pull aquasec/trivy:latest >/dev/null
+    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$PWD:/work" -w /work aquasec/trivy:latest image --severity HIGH,CRITICAL --scanners vuln --format sarif -o "$OUT" "$IMAGE"
+    exit $?
+fi
+trivy image --severity HIGH,CRITICAL --scanners vuln --format sarif -o "$OUT" "$IMAGE"
+echo "Trivy OK -> $OUT"


### PR DESCRIPTION
## Summary
- add pip-audit and trivy scripts for Windows (ps1) and Bash
- add Security Scans GitHub workflow uploading SARIF reports
- test presence and executability of security scripts

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `PYTHONPATH=backend pytest -q --cov=backend`


------
https://chatgpt.com/codex/tasks/task_e_68a77b691a548330a2cb984376900ab0