### PR TITLE
ETAPE 34 - Securite CI (pip-audit + Trivy) + SARIF

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,44 @@
+name: Security Scans
+on:
+  pull_request:
+    paths:
+      - "backend/**"
+      - "Dockerfile"
+      - "scripts/bash/sec_*"
+      - "PS1/sec_*"
+      - ".github/workflows/security.yml"
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  deps-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11", cache: "pip" }
+      - name: pip-audit (SARIF)
+        run: |
+          bash scripts/bash/sec_pip_audit.sh reports/pip-audit.sarif
+      - name: Upload SARIF (pip-audit)
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: reports/pip-audit.sarif
+
+  image-vuln:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image (ci)
+        run: docker build -t ccapi:cli-ci .
+      - name: Trivy image scan (SARIF)
+        run: |
+          bash scripts/bash/sec_trivy_image.sh ccapi:cli-ci reports/trivy.sarif
+      - name: Upload SARIF (trivy)
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: reports/trivy.sarif

--- a/PS1/sec_pip_audit.ps1
+++ b/PS1/sec_pip_audit.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = "Stop"
+param(
+    [string]$Output = "reports\pip-audit.sarif",
+    [string]$Format = "sarif"
+)
+Write-Host "Analyse dependances Python (pip-audit)..." -ForegroundColor Cyan
+python -m pip install --upgrade pip > $null
+python -m pip install pip-audit cyclonedx-bom > $null
+
+# Installer les deps du projet (dev) si pas deja fait
+
+python -m pip install -e backend[dev] > $null
+New-Item -ItemType Directory -Force -Path (Split-Path $Output) | Out-Null
+pip-audit -r backend/requirements.txt 2>$null | Out-Null
+
+# Si requirements.txt n existe pas, auditer l env courant (wheel installe)
+
+pip-audit -f $Format -o $Output || exit $LASTEXITCODE
+Write-Host "pip-audit termine. Rapport: $Output" -ForegroundColor Green

--- a/PS1/sec_trivy_image.ps1
+++ b/PS1/sec_trivy_image.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = "Stop"
+param(
+    [string]$Image = "ccapi:cli-ci",
+    [string]$Output = "reports\trivy.sarif"
+)
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Warning "Docker non installe; skip du scan d image."
+    exit 0
+}
+Write-Host "Scan image Docker ($Image) avec Trivy..." -ForegroundColor Cyan
+
+# Installe trivy portable via script shell dans un conteneur si absent
+
+if (-not (Get-Command trivy -ErrorAction SilentlyContinue)) {
+    Write-Host "Trivy non present; tentative d execution via conteneur..." -ForegroundColor Yellow
+    docker pull aquasec/trivy:latest > $null
+    New-Item -ItemType Directory -Force -Path (Split-Path $Output) | Out-Null
+    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$PWD:/work" -w /work aquasec/trivy:latest image --severity HIGH,CRITICAL --scanners vuln --format sarif -o $Output $Image
+    exit $LASTEXITCODE
+}
+trivy image --severity HIGH,CRITICAL --scanners vuln --format sarif -o $Output $Image

--- a/README.md
+++ b/README.md
@@ -513,6 +513,26 @@ bash scripts/bash/health_check.sh http://localhost:8001
 - Headers sécurité : `HSTS`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `CSP`, `Permissions-Policy`
 - CORS configurable
 
+### Securite CI (pip-audit & Trivy)
+
+* **Deps Python**: `pip-audit` produit un rapport SARIF et echoue sur vuln High/Critical.
+
+  ```
+  # Windows
+  powershell -File PS1\sec_pip_audit.ps1
+  # Bash
+  bash scripts/bash/sec_pip_audit.sh
+  ```
+* **Image Docker**: `trivy` scanne l image (si Docker dispo). Sans trivy local, le script utilise un conteneur `aquasec/trivy`.
+
+  ```
+  # Windows
+  powershell -File PS1\sec_trivy_image.ps1 -Image ccapi:cli-ci
+  # Bash
+  bash scripts/bash/sec_trivy_image.sh ccapi:cli-ci
+  ```
+* Les rapports SARIF sont uploades par le workflow `Security Scans` dans **Code scanning alerts**.
+
 ### En-tetes de securite
 
 Variables d env:

--- a/backend/tests/test_sec_scripts_exist.py
+++ b/backend/tests/test_sec_scripts_exist.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import stat
+import pathlib
+
+def test_sec_scripts_present_and_executable():
+    for p in [
+        "scripts/bash/sec_pip_audit.sh",
+        "scripts/bash/sec_trivy_image.sh",
+    ]:
+        f = pathlib.Path(p)
+        assert f.exists(), f"{p} manquant"
+        mode = f.stat().st_mode
+        assert mode & stat.S_IXUSR, f"{p} non executable"

--- a/scripts/bash/sec_pip_audit.sh
+++ b/scripts/bash/sec_pip_audit.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+OUT="${1:-reports/pip-audit.sarif}"
+mkdir -p "$(dirname "$OUT")"
+python -m pip install --upgrade pip >/dev/null
+python -m pip install pip-audit cyclonedx-bom >/dev/null
+python -m pip install -e backend[dev] >/dev/null
+
+# Si requirements.txt existe, l utiliser sinon auditer l env courant
+
+if [ -f backend/requirements.txt ]; then
+    pip-audit -r backend/requirements.txt >/dev/null || true
+fi
+pip-audit -f sarif -o "$OUT"

--- a/scripts/bash/sec_trivy_image.sh
+++ b/scripts/bash/sec_trivy_image.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IMAGE="${1:-ccapi:cli-ci}"
+OUT="${2:-reports/trivy.sarif}"
+mkdir -p "$(dirname "$OUT")"
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker non installe; skip du scan d image." >&2
+    exit 0
+fi
+if ! command -v trivy >/dev/null 2>&1; then
+    docker pull aquasec/trivy:latest >/dev/null
+    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$PWD:/work" -w /work aquasec/trivy:latest image --severity HIGH,CRITICAL --scanners vuln --format sarif -o "$OUT" "$IMAGE"
+    exit $?
+fi
+trivy image --severity HIGH,CRITICAL --scanners vuln --format sarif -o "$OUT" "$IMAGE"


### PR DESCRIPTION
## Summary
- add security scan scripts (pip-audit & trivy) for PowerShell and Bash
- run pip-audit & trivy in new Security Scans workflow and upload SARIF
- test presence and executable bits of security scripts

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `PYTHONPATH=backend pytest -q -k "sec_scripts_exist"`
- `bash scripts/bash/sec_pip_audit.sh /tmp/pip-audit.sarif` *(failed: pip-audit: command not found)*
- `bash scripts/bash/sec_trivy_image.sh ccapi:cli-ci /tmp/trivy.sarif` *(skipped: Docker non installe; skip du scan d image.)*

------
https://chatgpt.com/codex/tasks/task_e_68a76ff1c7c08330bf72a7c39915579b