### PR TITLE
ETAPE 35 - Smoke perf k6 (Docker) + CI

### DIFF
--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -1,0 +1,42 @@
+name: Load Test (k6)
+on:
+  pull_request:
+    paths:
+      - "backend/**"
+      - "Dockerfile"
+      - "docker-compose.k6.yml"
+      - "load/k6/**"
+      - "scripts/bash/load_k6.sh"
+      - "PS1/load_k6.ps1"
+      - ".github/workflows/k6.yml"
+  workflow_dispatch:
+
+jobs:
+  k6-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Compose up (backend)
+        run: docker compose -f docker-compose.k6.yml up -d --build
+      - name: Wait backend
+        run: |
+          for i in $(seq 1 90); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8001/healthz || true)
+            [ "$code" = "200" ] && break
+            sleep 2
+          done
+          [ "${code:-0}" = "200" ]
+      - name: Run k6 smoke
+        run: |
+          mkdir -p load/k6
+          docker run --rm --network cc-k6_default -v "$PWD/load/k6:/scripts" -e BASE="http://backend:8001" grafana/k6:latest run --vus 10 --duration 20s --summary-export /scripts/summary.json /scripts/smoke.js
+      - name: Upload k6 summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-summary
+          path: load/k6/summary.json
+      - name: Compose down
+        if: always()
+        run: docker compose -f docker-compose.k6.yml down -v

--- a/PS1/load_k6.ps1
+++ b/PS1/load_k6.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = "Stop"
+param(
+    [int]$VUs = 10,
+    [int]$Seconds = 20
+)
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Warning "Docker non installe; test k6 skippe."; exit 0
+}
+Write-Host "Build image backend..." -ForegroundColor Cyan
+docker build -t ccapi:k6 .
+Write-Host "Compose up backend..." -ForegroundColor Cyan
+docker compose -f docker-compose.k6.yml up -d --build
+
+# Attente sante
+
+for ($i=0; $i -lt 90; $i++) {
+    try {
+        $code = (Invoke-WebRequest -UseBasicParsing -Uri "http://localhost:8001/healthz" -TimeoutSec 2).StatusCode
+        if ($code -eq 200) { break }
+    } catch {}
+    Start-Sleep -Seconds 2
+}
+
+# Exec k6 via conteneur officiel; montee du script
+
+$env:BASE = "http://backend:8001"
+$summary = "load\k6\summary.json"
+New-Item -ItemType Directory -Force -Path "load\k6" | Out-Null
+docker run --rm --network cc-k6_default -v "$PWD/load/k6:/scripts" -e BASE=$env:BASE grafana/k6:latest run --vus $VUs --duration ${Seconds}s --summary-export /scripts/summary.json /scripts/smoke.js
+$rc = $LASTEXITCODE
+Write-Host "Compose down..." -ForegroundColor Yellow
+docker compose -f docker-compose.k6.yml down -v
+exit $rc

--- a/README.md
+++ b/README.md
@@ -441,6 +441,19 @@ DB_DSN=invalid:///nowhere PYTHONPATH=backend alembic upgrade head || echo "KO at
 ```
 
 
+### Smoke perf (k6)
+
+Lancer un test rapide (10 VUs / 20s):
+
+```
+# Windows
+powershell -File PS1\load_k6.ps1 -VUs 10 -Seconds 20
+# Linux/mac
+bash scripts/bash/load_k6.sh 10 20
+```
+
+Le rapport est ecrit dans `load/k6/summary.json`. En CI, le workflow **Load Test (k6)** uploade cet artefact.
+
 ## Tests et Qualité
 
 - Lint Python : `python -m ruff check backend`

--- a/backend/tests/test_k6_assets_exist.py
+++ b/backend/tests/test_k6_assets_exist.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import pathlib
+import stat
+
+
+def test_k6_assets_present():
+    for p in ["docker-compose.k6.yml", "load/k6/smoke.js", "scripts/bash/load_k6.sh", "PS1/load_k6.ps1"]:
+        f = pathlib.Path(p)
+        assert f.exists(), f"{p} manquant"
+        if f.suffix in (".sh",):
+            assert f.stat().st_mode & stat.S_IXUSR, f"{p} non executable"

--- a/docker-compose.k6.yml
+++ b/docker-compose.k6.yml
@@ -1,0 +1,18 @@
+name: cc-k6
+services:
+  backend:
+    build: .
+    environment:
+      ADMIN_AUTOSEED: "true"
+      ADMIN_USERNAME: admin
+      ADMIN_PASSWORD: admin123
+      FRONT_DIST_DIR: /app/public
+    ports:
+      - "8001:8001"
+    healthcheck:
+      test: ["CMD-SHELL","python - <<'PY'\nimport sys,urllib.request\ntry:\n  with urllib.request.urlopen('http://localhost:8001/healthz', timeout=2) as r:\n    sys.exit(0 if r.status==200 else 1)\nexcept Exception:\n  sys.exit(1)\nPY"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+# k6 se lance a la demande via scripts/CI; pas de container resident ici.

--- a/load/k6/smoke.js
+++ b/load/k6/smoke.js
@@ -1,0 +1,36 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+const BASE = __ENV.BASE || "http://backend:8001";
+
+export const options = {
+  scenarios: {
+    smoke: { executor: "constant-vus", vus: 10, duration: "20s" },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],          // < 1% d erreurs
+    http_req_duration: ["p(95)<500"],        // p95 < 500ms
+  },
+  summaryTrendStats: ["avg","min","med","p(90)","p(95)","p(99)","max"],
+};
+
+export default function () {
+  // 1) /healthz
+  const r1 = http.get(`${BASE}/healthz`, { tags: { name: "GET /healthz" } });
+  check(r1, { "healthz 200": (r) => r.status === 200 });
+
+  // 2) /metrics
+  const r2 = http.get(`${BASE}/metrics`, { tags: { name: "GET /metrics" } });
+  check(r2, { "metrics 200": (r) => r.status === 200 && String(r.body || "").includes("http_requests_total") });
+
+  // 3) /echo
+  const payload = JSON.stringify({ message: "hi" });
+  const headers = { "Content-Type": "application/json" };
+  const r3 = http.post(`${BASE}/echo?page=1&page_size=5`, payload, { headers, tags: { name: "POST /echo" } });
+  check(r3, {
+    "echo 200": (r) => r.status === 200,
+    "echo page passthrough": (r) => (r.json("page") === 1 && r.json("page_size") === 5),
+  });
+
+  sleep(0.2);
+}

--- a/scripts/bash/load_k6.sh
+++ b/scripts/bash/load_k6.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+VUS="${1:-10}"
+DUR="${2:-20}"
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker non installe; test k6 skippe." >&2
+  exit 0
+fi
+docker build -t ccapi:k6 .
+docker compose -f docker-compose.k6.yml up -d --build
+
+# wait health
+
+for i in $(seq 1 90); do
+  code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8001/healthz || true)
+  [ "$code" = "200" ] && break
+  sleep 2
+done
+mkdir -p load/k6
+docker run --rm --network cc-k6_default -v "$PWD/load/k6:/scripts" -e BASE="http://backend:8001" grafana/k6:latest run --vus "$VUS" --duration "${DUR}s" --summary-export /scripts/summary.json /scripts/smoke.js
+rc=$?
+docker compose -f docker-compose.k6.yml down -v
+exit $rc


### PR DESCRIPTION
## Summary
- add k6 smoke test script and dedicated compose file
- provide Windows and Bash helpers to run k6 locally
- run k6 smoke in CI and test asset presence

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `PYTHONPATH=backend pytest -q --cov=backend`
- `bash scripts/bash/load_k6.sh 2 5`

------
https://chatgpt.com/codex/tasks/task_e_68a781ba4e808330b259eb118137d45f