### PR TITLE
ETAPE 36 - Feature Flags (env) + /features + X-Features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,10 @@ DB_POOL_TIMEOUT=10
 REQUEST_ID_HEADER=X-Request-ID
 LOG_JSON=true
 
+# Features (comma-separated; inconnues ignorees)
+
+FEATURES_ENABLED="observability,rate-limit,openapi-export"
+
 # Rate limiting
 RATE_LIMIT_ENABLE=true
 RATE_LIMIT_GLOBAL_MAX=120

--- a/PS1/features.ps1
+++ b/PS1/features.ps1
@@ -1,0 +1,9 @@
+param([string]$Base = "http://localhost:8001")
+$ErrorActionPreference = "Stop"
+try {
+    $r = Invoke-WebRequest -UseBasicParsing -Uri "$Base/features" -TimeoutSec 5
+    Write-Host $r.Content
+    Write-Host ("X-Features: " + ($r.Headers["X-Features"])) -ForegroundColor Cyan
+} catch {
+    Write-Error "Echec GET $Base/features ($_)" ; exit 1
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Monorepo FastAPI (backend) + React Vite (frontend). Windows-first (PowerShell), 
 - [Tests (PowerShell + curl)](#tests-powershell--curl)
 - [Tests et Qualité](#tests-et-qualite)
 - [Observabilité](#observabilite)
+- [Feature Flags](#feature-flags)
 - [Sécurité](#securite)
 - [Dépannage](#depannage)
 - [Roadmap / Étapes livrées](#roadmap--etapes-livrees)
@@ -543,6 +544,22 @@ Scripts:
 powershell -File PS1/health_check.ps1 http://localhost:8001
 # Bash
 bash scripts/bash/health_check.sh http://localhost:8001
+```
+
+## Feature Flags
+
+* Variable d env: `FEATURES_ENABLED="comma,separated,list"`.
+* Features reconnues: `observability, rate-limit, openapi-export, redis-cache, alembic, cli-docker, security-headers, k6-smoke`.
+* Endpoint: `GET /features` -> JSON avec `known`, `enabled`, `raw`.
+* En-tete reponse: `X-Features` liste les features actives.
+
+Affichage rapide:
+
+```
+# Windows
+powershell -File PS1\features.ps1
+# Linux/mac
+bash scripts/bash/features.sh
 ```
 
 ## Sécurité

--- a/backend/app/features.py
+++ b/backend/app/features.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Dict, List, Set
+
+# Catalogue des features reconnues. Ajouter ici pour documenter/valider.
+
+KNOWN_FEATURES: Set[str] = {
+    "observability",
+    "rate-limit",
+    "openapi-export",
+    "redis-cache",
+    "alembic",
+    "cli-docker",
+    "security-headers",
+    "k6-smoke",
+}
+
+
+def parse_features(env_value: str | None) -> Dict[str, bool]:
+    """
+    Parse la liste CSV issue de FEATURES_ENABLED.
+    - Inconnues ignorees.
+    - Espaces ignores.
+    - Valeurs vides -> dict vide.
+    """
+    active: Set[str] = set()
+    if env_value:
+        for raw in env_value.split(","):
+            name = raw.strip()
+            if name and name in KNOWN_FEATURES:
+                active.add(name)
+    return {name: (name in active) for name in sorted(KNOWN_FEATURES)}
+
+
+def enabled_names(env_value: str | None) -> List[str]:
+    d = parse_features(env_value)
+    return [k for k, v in d.items() if v]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,9 @@ from .hash import hash_password
 from .rate_limit import get_limiter
 from .repo_users import create_user, get_by_username
 from .security_headers import SecurityHeadersMiddleware
+from .middleware_features import FeaturesHeaderMiddleware
 from .users_api import router as users_router
+from .routes_features import router as features_router
 
 _request_id_ctx: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "request_id", default=None
@@ -115,6 +117,7 @@ def create_app() -> FastAPI:
         )
 
     app.add_middleware(SecurityHeadersMiddleware)
+    app.add_middleware(FeaturesHeaderMiddleware)
 
     # Request ID middleware
     @app.middleware("http")
@@ -203,6 +206,7 @@ def create_app() -> FastAPI:
     app.include_router(api_router)
     app.include_router(users_router)
     app.include_router(audit_router)
+    app.include_router(features_router)
 
     Instrumentator().instrument(app).expose(app, endpoint="/metrics")
 

--- a/backend/app/middleware_features.py
+++ b/backend/app/middleware_features.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from .features import enabled_names
+
+
+class FeaturesHeaderMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_wrapper(message):
+            if message["type"] == "http.response.start":
+                feats = enabled_names(os.getenv("FEATURES_ENABLED"))
+                header_val = ",".join(feats) if feats else ""
+                headers = message.get("headers", [])
+                headers.append((b"x-features", header_val.encode("utf-8")))
+                message["headers"] = headers
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)

--- a/backend/app/routes_features.py
+++ b/backend/app/routes_features.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import os
+from fastapi import APIRouter
+
+from .features import KNOWN_FEATURES, parse_features
+
+router = APIRouter()
+
+
+@router.get("/features", tags=["features"])
+def get_features():
+    env_val = os.getenv("FEATURES_ENABLED")
+    parsed = parse_features(env_val)
+    return {
+        "known": sorted(KNOWN_FEATURES),
+        "enabled": [k for k, v in parsed.items() if v],
+        "raw": env_val or "",
+    }

--- a/backend/tests/test_features_flags.py
+++ b/backend/tests/test_features_flags.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from fastapi import FastAPI
+
+from app.features import KNOWN_FEATURES, parse_features
+from app.middleware_features import FeaturesHeaderMiddleware
+from app.routes_features import router as features_router
+
+
+def test_parse_features_ok_and_ignore_unknowns():
+    # Unknowns ignored
+    d = parse_features("observability, unknown1 , rate-limit, ,openapi-export,foo")
+    assert d["observability"] is True
+    assert d["rate-limit"] is True
+    assert d["openapi-export"] is True
+    # inconnues doivent exister dans le dict (False si non reconnues)
+    for k in KNOWN_FEATURES:
+        assert k in d
+    # features non citees -> False
+    assert d["redis-cache"] is False
+
+
+def test_endpoint_and_header(monkeypatch):
+    monkeypatch.setenv("FEATURES_ENABLED", "security-headers, k6-smoke")
+    app = FastAPI()
+    app.add_middleware(FeaturesHeaderMiddleware)
+    app.include_router(features_router)
+    c = TestClient(app)
+    r = c.get("/features")
+    assert r.status_code == 200
+    data = r.json()
+    assert "enabled" in data and "known" in data
+    # en-tete X-Features present
+    assert "x-features" in {k.lower(): v for k, v in r.headers.items()}
+    # la valeur de l en-tete reflète les actives
+    xf = r.headers.get("X-Features", "")
+    assert "security-headers" in xf and "k6-smoke" in xf

--- a/scripts/bash/features.sh
+++ b/scripts/bash/features.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE="${1:-http://localhost:8001}"
+body="$(curl -fsS "$BASE/features")"
+echo "$body"
+xf="$(curl -fsSI "$BASE/features" | awk 'BEGIN{IGNORECASE=1}/^X-Features\:/{print substr($0,index($0,$2))}')"
+echo "X-Features: ${xf}"


### PR DESCRIPTION
## Summary
- parse FEATURES_ENABLED env var into known feature flags
- expose `/features` endpoint and add `X-Features` header middleware
- document feature flags and provide PS1/Bash helper scripts

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `PYTHONPATH=backend pytest -q --cov=backend --cov-append -k "features_flags"`


------
https://chatgpt.com/codex/tasks/task_e_68a784d1c1988330b226107569f7f8b5