### PR TITLE
ETAPE 37 - CORS configurable via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,26 @@ JWT_ALGO=HS256
 JWT_TTL_SECONDS=3600
 REFRESH_JWT_SECRET=changeme-refresh-dev
 REFRESH_JWT_TTL_SECONDS=1209600
-CORS_ORIGINS=[http://localhost:3000,http://localhost:5173]
+
+# === CORS ===
+
+# Activer/desactiver CORS global
+CORS_ENABLE=true
+
+# Liste d'origines separees par des virgules (ex: http://localhost:5173,https://app.example.com)
+CORS_ALLOW_ORIGINS=http://localhost:5173
+
+# Liste methodes (GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD)
+CORS_ALLOW_METHODS=GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD
+
+# Liste headers autorises (ex: Authorization,Content-Type,If-None-Match)
+CORS_ALLOW_HEADERS=Authorization,Content-Type,If-None-Match,If-Match
+
+# Autoriser cookies/Authorization sur CORS
+CORS_ALLOW_CREDENTIALS=false
+
+# Cache preflight (secondes)
+CORS_MAX_AGE=600
 
 # Admin autoseed
 

--- a/PS1/cors_smoke.ps1
+++ b/PS1/cors_smoke.ps1
@@ -1,0 +1,13 @@
+param(
+    [string]$Base = "http://localhost:8001",
+    [string]$Origin = "http://localhost:5173"
+)
+$ErrorActionPreference = "Stop"
+$Headers = @{
+"Origin" = $Origin
+"Access-Control-Request-Method" = "POST"
+"Access-Control-Request-Headers" = "Authorization,Content-Type"
+}
+$r = Invoke-WebRequest -UseBasicParsing -Method Options -Uri "$Base/healthz" -Headers $Headers -TimeoutSec 5
+Write-Host "Status: $($r.StatusCode)"
+$r.Headers.GetEnumerator() | ? { $_.Name -like "Access-Control-*" } | % { Write-Host "$($_.Name): $($_.Value)" -ForegroundColor Cyan }

--- a/README.md
+++ b/README.md
@@ -96,9 +96,29 @@ Fichier `.env` à la racine. Voir `.env.example` fourni. Points clés:
 - `DB_DSN`: `sqlite:///./cc.db` (défaut) ou `postgresql+psycopg://user:pass@host:5432/db`
 - `ADMIN_AUTOSEED=true`, `ADMIN_USERNAME`, `ADMIN_PASSWORD`
 - JWT/REFRESH: secrets et TTL
-- `CORS_ORIGINS`: p. ex. `http://localhost:5173`
+- CORS_* : `CORS_ENABLE`, `CORS_ALLOW_ORIGINS`, `CORS_ALLOW_METHODS`, `CORS_ALLOW_HEADERS`, `CORS_ALLOW_CREDENTIALS`, `CORS_MAX_AGE`
 - Observabilité: `REQUEST_ID_HEADER`, `LOG_JSON`
 - Rate limiting: `RATE_LIMIT_*`
+
+### CORS (configurable)
+
+Variables d env:
+
+* `CORS_ENABLE=true|false`
+* `CORS_ALLOW_ORIGINS` (CSV) ex: `http://localhost:5173,https://app.example.com`
+* `CORS_ALLOW_METHODS` (CSV)
+* `CORS_ALLOW_HEADERS` (CSV)
+* `CORS_ALLOW_CREDENTIALS=true|false`
+* `CORS_MAX_AGE` (secondes, defaut 600)
+
+Smoke:
+
+```
+# Windows
+powershell -File PS1\cors_smoke.ps1 -Base http://localhost:8001 -Origin http://localhost:5173
+# Bash
+bash scripts/bash/cors_smoke.sh http://localhost:8001 http://localhost:5173
+```
 
 ## Scripts utiles
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
-
 import os
-
-
-def _split_csv(value: str) -> list[str]:
-    return [v.strip() for v in value.split(",") if v.strip()]
 
 
 class Settings:
@@ -22,7 +17,6 @@ class Settings:
     JWT_TTL_SECONDS: int = int(os.getenv("JWT_TTL_SECONDS", "3600"))
     REFRESH_JWT_SECRET: str = os.getenv("REFRESH_JWT_SECRET", "changeme-refresh-dev")
     REFRESH_JWT_TTL_SECONDS: int = int(os.getenv("REFRESH_JWT_TTL_SECONDS", "1209600"))
-    CORS_ORIGINS: list[str] = _split_csv(os.getenv("CORS_ORIGINS", ""))
 
     ADMIN_AUTOSEED: bool = os.getenv("ADMIN_AUTOSEED", "true").lower() == "true"
     ADMIN_USERNAME: str = os.getenv("ADMIN_USERNAME", "admin")

--- a/backend/app/cors_config.py
+++ b/backend/app/cors_config.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+from typing import List
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    v = os.getenv(name)
+    if v is None:
+        return default
+    return v.lower() in ("1", "true", "yes", "on")
+
+
+def _split_csv(name: str, default: str) -> List[str]:
+    raw = os.getenv(name, default)
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    return parts
+
+
+class CorsSettings:
+    def __init__(self) -> None:
+        self.enabled = _env_bool("CORS_ENABLE", True)
+        self.allow_origins = _split_csv("CORS_ALLOW_ORIGINS", "")
+        self.allow_methods = _split_csv(
+            "CORS_ALLOW_METHODS", "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+        )
+        self.allow_headers = _split_csv(
+            "CORS_ALLOW_HEADERS", "Authorization,Content-Type"
+        )
+        self.allow_credentials = _env_bool("CORS_ALLOW_CREDENTIALS", False)
+        try:
+            self.max_age = int(os.getenv("CORS_MAX_AGE", "600"))
+        except ValueError:
+            self.max_age = 600

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from fastapi import FastAPI, Request
-from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.cors import CORSMiddleware
 from prometheus_fastapi_instrumentator import Instrumentator
 from sqlalchemy.exc import IntegrityError
 from starlette.responses import JSONResponse, Response
@@ -25,6 +25,7 @@ from .hash import hash_password
 from .rate_limit import get_limiter
 from .repo_users import create_user, get_by_username
 from .security_headers import SecurityHeadersMiddleware
+from .cors_config import CorsSettings
 from .middleware_features import FeaturesHeaderMiddleware
 from .users_api import router as users_router
 from .routes_features import router as features_router
@@ -107,13 +108,16 @@ def create_app() -> FastAPI:
 
     app = FastAPI(title=settings.APP_NAME)
 
-    if settings.CORS_ORIGINS:
+    # === CORS ===
+    cs = CorsSettings()
+    if cs.enabled:
         app.add_middleware(
             CORSMiddleware,
-            allow_origins=settings.CORS_ORIGINS,
-            allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
+            allow_origins=cs.allow_origins or ["*"],
+            allow_methods=cs.allow_methods,
+            allow_headers=cs.allow_headers,
+            allow_credentials=cs.allow_credentials,
+            max_age=cs.max_age,
         )
 
     app.add_middleware(SecurityHeadersMiddleware)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -14,7 +14,8 @@ settings.RATE_LIMIT_AUTH_MAX = 10_000
 settings.ADMIN_AUTOSEED = True
 settings.ADMIN_USERNAME = "admin"
 settings.ADMIN_PASSWORD = "admin123"
-os.environ.setdefault("CORS_ORIGINS", "http://localhost:3000,http://localhost:5173")
+os.environ.setdefault("CORS_ENABLE", "true")
+os.environ.setdefault("CORS_ALLOW_ORIGINS", "http://localhost:3000,http://localhost:5173")
 
 
 @pytest.fixture(autouse=True)
@@ -25,7 +26,8 @@ def _test_env_toggles() -> Iterator[None]:
     settings.ADMIN_AUTOSEED = True
     settings.ADMIN_USERNAME = "admin"
     settings.ADMIN_PASSWORD = "admin123"
+    os.environ.setdefault("CORS_ENABLE", "true")
     os.environ.setdefault(
-        "CORS_ORIGINS", "http://localhost:3000,http://localhost:5173"
+        "CORS_ALLOW_ORIGINS", "http://localhost:3000,http://localhost:5173"
     )
     yield

--- a/backend/tests/test_cors_config.py
+++ b/backend/tests/test_cors_config.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+def _preflight(client: TestClient, origin: str, method: str, req_headers: str = "Authorization,Content-Type"):
+    return client.options(
+        "/healthz",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": method,
+            "Access-Control-Request-Headers": req_headers,
+        },
+    )
+
+
+def test_cors_preflight_ok(monkeypatch):
+    monkeypatch.setenv("CORS_ENABLE", "true")
+    monkeypatch.setenv("CORS_ALLOW_ORIGINS", "http://localhost:5173,https://app.example.com")
+    monkeypatch.setenv("CORS_ALLOW_METHODS", "GET,POST")
+    monkeypatch.setenv("CORS_ALLOW_HEADERS", "Authorization,Content-Type")
+    app = create_app()
+    c = TestClient(app)
+    r = _preflight(c, "http://localhost:5173", "POST")
+    assert r.status_code in (200, 204)
+    h = {k.lower(): v for k, v in r.headers.items()}
+    assert h.get("access-control-allow-origin") == "http://localhost:5173"
+    assert "authorization" in h.get("access-control-allow-headers", "").lower()
+    assert "post" in h.get("access-control-allow-methods", "").lower()
+
+
+def test_cors_disabled_no_headers(monkeypatch):
+    monkeypatch.setenv("CORS_ENABLE", "false")
+    app = create_app()
+    c = TestClient(app)
+    r = _preflight(c, "http://localhost:5173", "GET")
+    h = {k.lower(): v for k, v in r.headers.items()}
+    assert "access-control-allow-origin" not in h

--- a/scripts/bash/api_start_autoseed.sh
+++ b/scripts/bash/api_start_autoseed.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 : "${JWT_SECRET:=ci-secret}"
 : "${JWT_ALGO:=HS256}"
 : "${JWT_TTL_SECONDS:=3600}"
-: "${CORS_ORIGINS:=http://localhost:3000,http://localhost:5173}"
+: "${CORS_ENABLE:=true}"
+: "${CORS_ALLOW_ORIGINS:=http://localhost:3000,http://localhost:5173}"
 : "${DB_DSN:=sqlite:///./cc.db}"
 python -m pip install --upgrade pip >/dev/null
 pip install -q -e backend[dev]

--- a/scripts/bash/cors_smoke.sh
+++ b/scripts/bash/cors_smoke.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE="${1:-http://localhost:8001}"
+ORIGIN="${2:-http://localhost:5173}"
+curl -i -X OPTIONS "$BASE/healthz" \
+  -H "Origin: $ORIGIN" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: Authorization,Content-Type" \
+  | sed -n '1,30p' | awk 'BEGIN{IGNORECASE=1}/^Access-Control-/{print}'


### PR DESCRIPTION
## Summary
- add environment-driven CorsSettings and conditional Starlette CORSMiddleware
- document CORS env vars and add smoke scripts for Windows and Bash
- cover CORS preflight and disabled scenarios with tests

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `PYTHONPATH=backend pytest -q --cov=backend -k "cors_config" --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68a789493fe88330a6f8de9a32c4a5ae