### PR TITLE
feat(infra): monitoring Prometheus+Grafana+Alertmanager+Exporters

### DIFF
--- a/README-MONITORING.md
+++ b/README-MONITORING.md
@@ -1,0 +1,36 @@
+# Monitoring (Prometheus, Alertmanager, Grafana, Blackbox, cAdvisor)
+
+Prerequis:
+
+* Docker Desktop
+* Fichier monitoring/.env base sur .env.example
+
+Demarrage:
+
+* PowerShell:
+  .\scripts\ps1\monitoring\up.ps1 -EnvFile monitoring/.env
+* Bash:
+  ./scripts/bash/monitoring/up.sh monitoring/.env
+
+Acces:
+
+* Prometheus: http://localhost:9090
+* Alertmanager: http://localhost:9093
+* Grafana: http://localhost:3000 (admin/admin par defaut, a changer)
+* Blackbox exporter: http://localhost:9115/metrics
+* cAdvisor: http://localhost:8080
+
+Test OK:
+
+* .\scripts\ps1\monitoring\test_ok.ps1
+
+Test KO (manuel force):
+
+* Editer monitoring/.env -> PUBLIC_API_URL=http://127.0.0.1:9/healthz
+* Redemarrer la stack (down puis up)
+* Sur Prometheus, la requete probe_success{job="blackbox_api"} doit valoir 0.
+
+Notes:
+
+* Aucune alerte n envoie de notification par defaut (receiver null). Ajouter une integration (email/telegram) en prod.
+* Retention Prometheus par defaut; ajuster via flags si besoin.

--- a/monitoring/.env.example
+++ b/monitoring/.env.example
@@ -1,0 +1,13 @@
+PROMETHEUS_PORT=9090
+ALERTMANAGER_PORT=9093
+GRAFANA_PORT=3000
+BLACKBOX_EXPORTER_PORT=9115
+
+# Cible de supervision HTTP (utilisee par blackbox exporter)
+
+PUBLIC_API_URL=http://localhost/healthz
+
+# Grafana admin (changer en prod)
+
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin

--- a/monitoring/alertmanager/alertmanager.yml
+++ b/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,13 @@
+global:
+  resolve_timeout: 5m
+route:
+  receiver: "null"
+  group_by: ["alertname"]
+  group_wait: 10s
+  group_interval: 1m
+  repeat_interval: 2h
+receivers:
+  - name: "null"
+    webhook_configs: []
+
+# Integration e-mail/telegram a ajouter en prod via variables d'environnement.

--- a/monitoring/blackbox/blackbox.yml
+++ b/monitoring/blackbox/blackbox.yml
@@ -1,0 +1,8 @@
+modules:
+  http_2xx:
+    prober: http
+    timeout: 10s
+    http:
+      method: GET
+      valid_http_versions: ["HTTP/1.1", "HTTP/2"]
+      preferred_ip_protocol: "ip4"

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,59 @@
+version: "3.9"
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: prometheus
+    restart: unless-stopped
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alerts:/etc/prometheus/alerts:ro
+      - prom_data:/prometheus
+    depends_on:
+      - blackbox
+      - cadvisor
+      - alertmanager
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: alertmanager
+    restart: unless-stopped
+    ports:
+      - "${ALERTMANAGER_PORT:-9093}:9093"
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+  blackbox:
+    image: prom/blackbox-exporter:v0.25.0
+    container_name: blackbox
+    restart: unless-stopped
+    ports:
+      - "${BLACKBOX_EXPORTER_PORT:-9115}:9115"
+    volumes:
+      - ./blackbox/blackbox.yml:/etc/blackbox_exporter/config.yml:ro
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    container_name: cadvisor
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+  grafana:
+    image: grafana/grafana:10.4.3
+    container_name: grafana
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+    volumes:
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+volumes:
+  prom_data:

--- a/monitoring/grafana/dashboards/api.json
+++ b/monitoring/grafana/dashboards/api.json
@@ -1,0 +1,33 @@
+{
+  "title": "API Availability (Blackbox)",
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Probe Success",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "probe_success{job=\"blackbox_api\"}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP p95 Duration (s)",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum(rate(probe_http_duration_seconds_bucket{job=\"blackbox_api\"}[5m])) by (le))" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP Status Codes",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "sum by (status_code)(rate(probe_http_status_code{job=\"blackbox_api\"}[5m]))" }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/dash.yml
+++ b/monitoring/grafana/provisioning/dashboards/dash.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+  - name: default
+    orgId: 1
+    folder: ""
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/ds.yml
+++ b/monitoring/grafana/provisioning/datasources/ds.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus/alerts/api_availability.yml
+++ b/monitoring/prometheus/alerts/api_availability.yml
@@ -1,0 +1,20 @@
+groups:
+  - name: api.availability
+    rules:
+      - alert: ApiDown
+        expr: probe_success{job="blackbox_api"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "API indisponible"
+          description: "La sonde HTTP echoue depuis 1m."
+
+      - alert: ApiLatencyHigh
+        expr: histogram_quantile(0.95, sum(rate(probe_http_duration_seconds_bucket{job="blackbox_api"}[5m])) by (le)) > 0.5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Latence API elevee (p95 > 500ms)"
+          description: "Verifier charge, DB, reverse proxy et reseau."

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,36 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  scrape_timeout: 10s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
+rule_files:
+  - /etc/prometheus/alerts/*.yml
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["prometheus:9090"]
+
+  - job_name: cadvisor
+    static_configs:
+      - targets: ["cadvisor:8080"]
+
+  - job_name: blackbox_api
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets:
+          - "${PUBLIC_API_URL}"
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox:9115

--- a/scripts/bash/monitoring/down.sh
+++ b/scripts/bash/monitoring/down.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+docker compose -f monitoring/docker-compose.monitoring.yml down -v
+echo "Stack monitoring arretee et volumes supprimes."

--- a/scripts/bash/monitoring/logs.sh
+++ b/scripts/bash/monitoring/logs.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+docker compose -f monitoring/docker-compose.monitoring.yml logs -f --tail=200

--- a/scripts/bash/monitoring/up.sh
+++ b/scripts/bash/monitoring/up.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ENV_FILE="${1:-monitoring/.env}"
+if [ -f "$ENV_FILE" ]; then
+  set -a; source "$ENV_FILE"; set +a
+fi
+docker compose -f monitoring/docker-compose.monitoring.yml up -d
+echo "Stack monitoring demarree."

--- a/scripts/ps1/monitoring/down.ps1
+++ b/scripts/ps1/monitoring/down.ps1
@@ -1,0 +1,2 @@
+docker compose -f monitoring/docker-compose.monitoring.yml down -v
+Write-Host "Stack monitoring arretee et volumes supprimes." -ForegroundColor Yellow

--- a/scripts/ps1/monitoring/logs.ps1
+++ b/scripts/ps1/monitoring/logs.ps1
@@ -1,0 +1,1 @@
+docker compose -f monitoring/docker-compose.monitoring.yml logs -f --tail=200

--- a/scripts/ps1/monitoring/test_ko.ps1
+++ b/scripts/ps1/monitoring/test_ko.ps1
@@ -1,0 +1,16 @@
+param(
+    [string]$Prom="http://localhost:9090"
+)
+Write-Host "Test KO: blackbox en echec volontaire" -ForegroundColor Yellow
+
+# On simule une URL invalide temporairement via API v1 de reload (simple check metrics sans reload:
+# on attend simplement que probe_success tombe a 0 pour une cible injoignable)
+# Ici, on verifie juste la presence de la serie probe_success et que sa valeur est 0 si la cible est KO.
+
+$metric = Invoke-WebRequest -UseBasicParsing "$Prom/api/v1/query?query=probe_success%7Bjob%3D%22blackbox_api%22%7D" -TimeoutSec 5 | ConvertFrom-Json
+$vals = $metric.data.result.value
+if (-not $vals) { Write-Host "Pas de metrics probe_success. KO attendu non verifiable." -ForegroundColor Red; exit 1 }
+
+# On accepte 0 ou 1 selon l etat. Pour forcer un vrai KO, l operateur devra mettre PUBLIC_API_URL=http://127.0.0.1:9/healthz et relancer up.
+Write-Host "Metric probe_success presente. Valeur actuelle: $($vals[1])." -ForegroundColor Cyan
+Write-Host "KO veritable a tester en pointant une URL invalide dans monitoring/.env puis relance." -ForegroundColor Yellow

--- a/scripts/ps1/monitoring/test_ok.ps1
+++ b/scripts/ps1/monitoring/test_ok.ps1
@@ -1,0 +1,14 @@
+param(
+    [string]$Prom="http://localhost:9090",
+    [string]$Graf="http://localhost:3000"
+)
+Write-Host "Test OK: endpoints Prometheus et Grafana accesibles" -ForegroundColor Cyan
+try {
+    $p = Invoke-WebRequest -UseBasicParsing "$Prom/-/ready" -TimeoutSec 5
+    if ($p.StatusCode -ne 200) { throw "Prometheus non pret (HTTP $($p.StatusCode))" }
+    $g = Invoke-WebRequest -UseBasicParsing "$Graf/login" -TimeoutSec 5
+    if ($g.StatusCode -ne 200) { throw "Grafana non accessible (HTTP $($g.StatusCode))" }
+    Write-Host "OK" -ForegroundColor Green
+} catch {
+    Write-Host "Echec: $($_.Exception.Message)" -ForegroundColor Red; exit 1
+}

--- a/scripts/ps1/monitoring/up.ps1
+++ b/scripts/ps1/monitoring/up.ps1
@@ -1,0 +1,12 @@
+param(
+    [string]$EnvFile = "monitoring/.env"
+)
+Write-Host "Chargement env depuis $EnvFile" -ForegroundColor Cyan
+if (Test-Path $EnvFile) { Get-Content $EnvFile | foreach {
+    if ($_ -match "^\s*$") { return }
+    if ($_ -match "^\s*#") { return }
+    $k,$v = $_.Split("=",2)
+    $env:$k = $v
+}}
+docker compose -f monitoring/docker-compose.monitoring.yml up -d
+Write-Host "Stack monitoring demarree." -ForegroundColor Green


### PR DESCRIPTION
## Summary
- add Prometheus, Alertmanager, Grafana, blackbox exporter and cAdvisor docker compose stack
- provision Prometheus alerts and Grafana dashboards
- add Windows-first PowerShell and Bash scripts for managing and testing the monitoring stack

## Testing
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/ps1/monitoring/up.ps1` (fails: command not found)
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/ps1/monitoring/test_ok.ps1` (fails: command not found)
- `./scripts/bash/monitoring/up.sh monitoring/.env` (fails: docker: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a78d4abb00833087500377f7738dec