### PR TITLE
feat(infra): add CDN/assets cache (etag, gzip/br)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,3 +124,6 @@ X_FRAME_OPTIONS='DENY'
 # Permissions-Policy (exemple minimal)
 
 PERMISSIONS_POLICY="geolocation=(), microphone=(), camera=()"
+
+# CDN
+CDN_URL=http://localhost

--- a/README-CDN.md
+++ b/README-CDN.md
@@ -1,0 +1,7 @@
+# CDN / Cache HTTP
+
+* Headers added: Cache-Control (1 year + immutable), ETag, Content-Encoding (gzip/br).
+* Test Windows:
+  .\scripts\ps1\cdn\test_headers.ps1 -Url http://localhost/app.js
+* Test Bash:
+  ./scripts/bash/cdn/test_headers.sh http://localhost/app.js

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,0 +1,21 @@
+{
+auto_https off
+servers {
+protocol {
+experimental_http3
+}
+}
+}
+
+:80 {
+root * /app/frontend/dist
+encode gzip zstd br
+file_server
+
+@static {
+    path *.js *.css *.ico *.png *.jpg *.svg *.woff2
+    file
+}
+header @static Cache-Control "public, max-age=31536000, immutable"
+header @static ETag {file.etag}
+}

--- a/scripts/bash/cdn/test_headers.sh
+++ b/scripts/bash/cdn/test_headers.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+URL="${1:-http://localhost/app.js}"
+echo "Test headers for $URL"
+curl --compressed -s -D - -o /dev/null "$URL" | grep -Ei "Cache-Control|ETag|Content-Encoding"

--- a/scripts/ps1/cdn/test_headers.ps1
+++ b/scripts/ps1/cdn/test_headers.ps1
@@ -1,0 +1,8 @@
+param(
+    [string]$Url = "http://localhost/app.js"
+)
+Write-Host "Test headers for $Url" -ForegroundColor Cyan
+$response = curl -s --compressed -D - -o NUL $Url
+$response | Select-String -Pattern "Cache-Control"
+$response | Select-String -Pattern "ETag"
+$response | Select-String -Pattern "Content-Encoding"


### PR DESCRIPTION
## Summary
- serve static files via Caddy with cache headers and compression
- add header test scripts for Bash and PowerShell
- document CDN config and env var

## Testing
- `./scripts/bash/cdn/test_headers.sh http://localhost/app.js`
- `curl -s -D - -o /dev/null http://localhost/missing.js`
- `pwsh -NoLogo -File scripts/ps1/cdn/test_headers.ps1 -Url http://localhost/app.js` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

Labels: infra, performance
Assignees: @owner

------
https://chatgpt.com/codex/tasks/task_e_68a78f522a90833084486fed62e099d7