### PR TITLE
feat(auth): RBAC par routes (roles) + deps + exemples + tests + scripts

### DIFF
--- a/README-RBAC.md
+++ b/README-RBAC.md
@@ -1,0 +1,25 @@
+# RBAC par routes (roles)
+
+* Ajoute des dependances FastAPI:
+  * get_current_principal: decode JWT (Bearer), 401 si manquant/invalide
+  * require_roles([roles]): 403 si aucun des roles requis n est present
+* Endpoints d exemple:
+  * GET /me/ping -> auth requise (n importe quel role)
+  * GET /admin/ping -> role "admin" requis
+
+Tests:
+
+* PYTHONPATH=backend pytest -q backend/tests/test_rbac.py
+  Attendu: 4 passed
+
+Scripts Windows/Bash:
+
+* Generer un token admin et tester /admin/ping
+  .\scripts\ps1\rbac\test_admin_ok.ps1 -BaseUrl http://localhost:8000 -Secret <votre_secret>
+* Tester KO (403)
+  .\scripts\ps1\rbac\test_admin_ko.ps1 -BaseUrl http://localhost:8000 -Secret <votre_secret>
+
+Notes:
+
+* Les roles sont verifies par intersection (OR logique). Pour exiger plusieurs roles simultanes, etendre la fonction require_roles selon besoin.
+* Integration avec un modele User/DB et mappage des roles viendra dans une etape ulterieure.

--- a/backend/app/core/rbac.py
+++ b/backend/app/core/rbac.py
@@ -1,0 +1,49 @@
+from typing import List, Set
+
+from fastapi import Depends, HTTPException, Request, status
+
+from .config import get_settings
+from .security import decode_jwt
+
+
+def get_current_principal(request: Request):
+    auth = request.headers.get("Authorization")
+    if not auth or not auth.lower().startswith("bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Token manquant"
+        )
+    token = auth.split(" ", 1)[1].strip()
+    settings = get_settings()
+    payload = decode_jwt(token, settings.JWT_SECRET, [settings.JWT_ALGO])
+    roles = payload.get("roles")
+    if roles is None:
+        role = payload.get("role")
+        roles = [role] if role else []
+    if not isinstance(roles, list):
+        roles = []
+    principal = {
+        "sub": payload.get("sub"),
+        "email": payload.get("email"),
+        "roles": roles,
+        "payload": payload,
+    }
+    return principal
+
+
+def require_roles(required: List[str]):
+    req: Set[str] = set([r.strip() for r in required if r and r.strip()])
+    if not req:
+        async def _noop(principal=Depends(get_current_principal)):
+            return principal
+        return _noop
+
+    async def _enforcer(principal=Depends(get_current_principal)):
+        roles = set(principal.get("roles") or [])
+        if roles.intersection(req):
+            return principal
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Acces refuse: role insuffisant",
+        )
+
+    return _enforcer

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,19 @@
+from typing import Any, Dict, List
+
+import jwt
+from jwt import InvalidTokenError
+from fastapi import HTTPException, status
+
+
+def decode_jwt(token: str, secret: str, algorithms: List[str]) -> Dict[str, Any]:
+    try:
+        payload = jwt.decode(token, secret, algorithms=algorithms)
+        if not isinstance(payload, dict):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Token invalide"
+            )
+        return payload
+    except InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Token invalide"
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,6 +30,7 @@ from .cors_config import CorsSettings
 from .middleware_features import FeaturesHeaderMiddleware
 from .users_api import router as users_router
 from .routes_features import router as features_router
+from .routers.protected import router as protected_router
 
 _request_id_ctx: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "request_id", default=None
@@ -213,6 +214,7 @@ def create_app() -> FastAPI:
     app.include_router(users_router)
     app.include_router(audit_router)
     app.include_router(features_router)
+    app.include_router(protected_router)
 
     @app.get("/_meta/scaling")
     def scaling_meta():  # noqa: D401 - expose current scaling env vars

--- a/backend/app/routers/protected.py
+++ b/backend/app/routers/protected.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+from ..core.rbac import get_current_principal, require_roles
+
+router = APIRouter(prefix="", tags=["protected"])
+
+
+@router.get("/me/ping")
+async def me_ping(principal=Depends(get_current_principal)):
+    return JSONResponse(
+        {"ok": True, "user": {"sub": principal.get("sub"), "roles": principal.get("roles")}}
+    )
+
+
+@router.get("/admin/ping")
+async def admin_ping(principal=Depends(require_roles(["admin"]))):
+    return JSONResponse(
+        {
+            "ok": True,
+            "admin": True,
+            "user": {"sub": principal.get("sub"), "roles": principal.get("roles")},
+        }
+    )

--- a/backend/tests/test_rbac.py
+++ b/backend/tests/test_rbac.py
@@ -1,0 +1,56 @@
+import jwt
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+SECRET = "testsecret"
+ALGO = "HS256"
+
+
+def make_token(sub="u1", roles=None, email=None):
+    roles = roles or []
+    payload = {"sub": sub, "roles": roles}
+    if email:
+        payload["email"] = email
+    return jwt.encode(payload, SECRET, algorithm=ALGO)
+
+
+def test_me_ping_ok_with_any_token(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", SECRET)
+    monkeypatch.setenv("JWT_ALGO", ALGO)
+    app = create_app()
+    c = TestClient(app)
+    tok = make_token(roles=["user"])
+    r = c.get("/me/ping", headers={"Authorization": f"Bearer {tok}"})
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+
+def test_admin_ping_forbidden_without_admin(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", SECRET)
+    monkeypatch.setenv("JWT_ALGO", ALGO)
+    app = create_app()
+    c = TestClient(app)
+    tok = make_token(roles=["user"])
+    r = c.get("/admin/ping", headers={"Authorization": f"Bearer {tok}"})
+    assert r.status_code == 403
+
+
+def test_admin_ping_ok_with_admin(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", SECRET)
+    monkeypatch.setenv("JWT_ALGO", ALGO)
+    app = create_app()
+    c = TestClient(app)
+    tok = make_token(roles=["admin"])
+    r = c.get("/admin/ping", headers={"Authorization": f"Bearer {tok}"})
+    assert r.status_code == 200
+    assert r.json()["admin"] is True
+
+
+def test_unauthenticated_gets_401(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", SECRET)
+    monkeypatch.setenv("JWT_ALGO", ALGO)
+    app = create_app()
+    c = TestClient(app)
+    r = c.get("/admin/ping")
+    assert r.status_code == 401

--- a/scripts/bash/rbac/make_token.sh
+++ b/scripts/bash/rbac/make_token.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SUB="${1:-u-local}"; ROLES="${2:-user}"; SECRET="${3:-change_me}"; ALGO="${4:-HS256}"
+python - "$SUB" "$ROLES" "$SECRET" "$ALGO" <<'PY'
+import os, sys, jwt
+sub, roles, secret, algo = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+roles_list = [r.strip() for r in roles.split(',') if r.strip()]
+payload = {"sub": sub, "roles": roles_list}
+print(jwt.encode(payload, secret, algorithm=algo))
+PY

--- a/scripts/bash/rbac/test_admin_ko.sh
+++ b/scripts/bash/rbac/test_admin_ko.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE_URL="${1:-http://localhost:8000}"
+SECRET="${2:-change_me}"
+TOK=$("$(dirname "$0")/make_token.sh" u-user user "$SECRET")
+curl -s -D - -o /dev/null -H "Authorization: Bearer ${TOK}" "${BASE_URL}/admin/ping"

--- a/scripts/bash/rbac/test_admin_ok.sh
+++ b/scripts/bash/rbac/test_admin_ok.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE_URL="${1:-http://localhost:8000}"
+SECRET="${2:-change_me}"
+TOK=$("$(dirname "$0")/make_token.sh" u-admin admin "$SECRET")
+curl -s -H "Authorization: Bearer ${TOK}" "${BASE_URL}/admin/ping"

--- a/scripts/ps1/rbac/make_token.ps1
+++ b/scripts/ps1/rbac/make_token.ps1
@@ -1,0 +1,19 @@
+param(
+[string]$Sub = "u-local",
+[string]$Roles = "user",
+[string]$Secret = "change_me",
+[string]$Algo = "HS256"
+)
+
+# Utilise Python pour generer un JWT (PyJWT doit etre installe)
+
+$code = @'
+import os, sys, json, jwt
+sub, roles, secret, algo = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+roles_list = [r.strip() for r in roles.split(',') if r.strip()]
+payload = {"sub": sub, "roles": roles_list}
+print(jwt.encode(payload, secret, algorithm=algo))
+'@
+python - <<PY $Sub $Roles $Secret $Algo
+$code
+PY

--- a/scripts/ps1/rbac/test_admin_ko.ps1
+++ b/scripts/ps1/rbac/test_admin_ko.ps1
@@ -1,0 +1,6 @@
+param(
+[string]$BaseUrl = "http://localhost:8000",
+[string]$Secret = "change_me"
+)
+$tok = & $PSScriptRoot/make_token.ps1 -Sub "u-user" -Roles "user" -Secret $Secret
+curl -s -D - -o NUL -H @{"Authorization" = "Bearer $tok"} "$BaseUrl/admin/ping"

--- a/scripts/ps1/rbac/test_admin_ok.ps1
+++ b/scripts/ps1/rbac/test_admin_ok.ps1
@@ -1,0 +1,6 @@
+param(
+[string]$BaseUrl = "http://localhost:8000",
+[string]$Secret = "change_me"
+)
+$tok = & $PSScriptRoot/make_token.ps1 -Sub "u-admin" -Roles "admin" -Secret $Secret
+curl -s -H @{"Authorization" = "Bearer $tok"} "$BaseUrl/admin/ping"


### PR DESCRIPTION
## Summary
- add JWT decoding helper and RBAC deps
- expose sample protected endpoints with role checks
- provide tests and Windows/Bash scripts for token generation and verification

## Testing
- `PYTHONPATH=backend pytest -q backend/tests/test_rbac.py`
- `pwsh -NoProfile -File scripts/ps1/rbac/make_token.ps1 -Sub test -Roles admin -Secret testsecret` *(fails: command not found)*
- `scripts/bash/rbac/make_token.sh test admin testsecret HS256`


------
https://chatgpt.com/codex/tasks/task_e_68a796282e048330ac22d5bb8ffa8c20