### PR TITLE
chore(docs): onboarding dev Windows-first (scripts PS1/Bash, quickstart)

### DIFF
--- a/README-ONBOARDING.md
+++ b/README-ONBOARDING.md
@@ -1,0 +1,43 @@
+# Onboarding developpeur (Windows-first)
+
+## 1. Pre-requis
+
+* Windows 10/11
+* Python 3.11+
+* Git
+* (Optionnel) Docker Desktop, Node.js, MkDocs
+
+## 2. Premiere installation
+
+```powershell
+# Verifier pre-requis
+.\scripts\ps1\onboarding\check_env.ps1 -MinPython 3.11
+
+# Copier l env dev
+.\scripts\ps1\onboarding\copy_env.ps1 -Src .env.dev.example -Dst .env
+
+# Installer deps backend
+.\scripts\ps1\onboarding\setup_backend.ps1
+
+# Demarrer l API
+.\scripts\ps1\onboarding\dev_up.ps1 -Port 8000 -Reload
+```
+
+Ouvrir http://localhost:8000/healthz -> 200
+
+## 3. Tests rapides
+
+```powershell
+.\scripts\ps1\onboarding\dev_test.ps1
+```
+
+## 4. Arret
+
+```powershell
+.\scripts\ps1\onboarding\dev_down.ps1 -Port 8000
+```
+
+## 5. E2E OK / KO
+
+* OK: `.\scripts\ps1\onboarding\test_ok.ps1`
+* KO: `.\scripts\ps1\onboarding\test_ko.ps1`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest==8.3.2
+pytest-cov==5.0.0
+httpx==0.27.2
+ruff==0.6.4
+mypy==1.10.0

--- a/scripts/bash/onboarding/check_env.sh
+++ b/scripts/bash/onboarding/check_env.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+MIN_PY="${1:-3.11}"
+PYV=$(python - <<PY
+import sys
+print("%d.%d.%d"%sys.version_info[:3])
+PY
+) || PYV=""
+ok=0
+if [ -z "$PYV" ]; then echo "Python introuvable"; exit 2; fi
+verlte() { [ "$1" = "$2" ] && return 0 || [  "$(printf "%s\n%s\n" "$1" "$2" | sort -V | head -n1)" = "$1" ]; }
+if verlte "$MIN_PY" "$PYV"; then echo "Python $PYV OK"; ok=1; else echo "Python $PYV < $MIN_PY"; fi
+[ $ok -eq 1 ] || exit 2

--- a/scripts/bash/onboarding/dev_down.sh
+++ b/scripts/bash/onboarding/dev_down.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PORT="${1:-8000}"
+pkill -f "uvicorn .*--port $PORT" || true
+echo "OK: backend stoppe"

--- a/scripts/bash/onboarding/dev_up.sh
+++ b/scripts/bash/onboarding/dev_up.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PORT="${1:-8000}"
+export PYTHONPATH=backend
+python -m uvicorn backend.app.main:app --host 0.0.0.0 --port "$PORT" &
+sleep 2
+code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/healthz)
+[ "$code" = "200" ] && echo "OK: healthz 200" || { echo "KO: $code"; exit 3; }

--- a/scripts/bash/onboarding/setup_backend.sh
+++ b/scripts/bash/onboarding/setup_backend.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python -m venv .venv || true
+source .venv/bin/activate
+pip install -U pip
+[ -f requirements.txt ] && pip install -r requirements.txt || true
+[ -f requirements-dev.txt ] && pip install -r requirements-dev.txt || true
+echo "OK: deps installees"

--- a/scripts/ps1/onboarding/check_env.ps1
+++ b/scripts/ps1/onboarding/check_env.ps1
@@ -1,0 +1,30 @@
+param(
+[string]$MinPython = "3.11"
+)
+function Compare-Version($a,$b){
+$A = [version]$a; $B = [version]$b; return $A.CompareTo($B)
+}
+$ok = $true
+Write-Host "== Verification pre-requis ==" -ForegroundColor Cyan
+
+# Python
+
+try { $pyV = (python -c "import sys; print('.'.join(map(str, sys.version_info[:3])))") } catch { $pyV = $null }
+if (-not $pyV) { Write-Host "Python introuvable" -ForegroundColor Red; $ok=$false } else {
+if ((Compare-Version $pyV $MinPython) -lt 0) { Write-Host "Python $pyV < $MinPython" -ForegroundColor Red; $ok=$false } else { Write-Host "Python $pyV OK" -ForegroundColor Green }
+}
+
+# pip
+
+try { pip --version | Out-Null; Write-Host "pip OK" -ForegroundColor Green } catch { Write-Host "pip introuvable" -ForegroundColor Yellow }
+
+# git
+
+try { git --version | Out-Null; Write-Host "git OK" -ForegroundColor Green } catch { Write-Host "git introuvable" -ForegroundColor Yellow }
+
+# Optionnels
+
+try { docker --version | Out-Null; Write-Host "docker present (optionnel)" -ForegroundColor DarkGreen } catch {}
+try { node --version | Out-Null; Write-Host "node present (optionnel)" -ForegroundColor DarkGreen } catch {}
+try { mkdocs --version | Out-Null; Write-Host "mkdocs present (optionnel)" -ForegroundColor DarkGreen } catch {}
+if (-not $ok) { exit 2 } else { exit 0 }

--- a/scripts/ps1/onboarding/copy_env.ps1
+++ b/scripts/ps1/onboarding/copy_env.ps1
@@ -1,0 +1,8 @@
+param(
+[string]$Src = ".env.dev.example",
+[string]$Dst = ".env"
+)
+if (Test-Path $Dst) { Write-Host "$Dst existe deja, skip" -ForegroundColor Yellow; exit 0 }
+if (-not (Test-Path $Src)) { Write-Host "$Src introuvable" -ForegroundColor Red; exit 2 }
+Copy-Item $Src $Dst -Force
+Write-Host "OK: $Src -> $Dst" -ForegroundColor Green

--- a/scripts/ps1/onboarding/dev_down.ps1
+++ b/scripts/ps1/onboarding/dev_down.ps1
@@ -1,0 +1,5 @@
+param([int]$Port=8000)
+Get-NetTCPConnection -LocalPort $Port -ErrorAction SilentlyContinue | ForEach-Object {
+try { Stop-Process -Id $_.OwningProcess -Force -ErrorAction Stop } catch {}
+}
+Write-Host "OK: backend dev stoppe (port :$Port)" -ForegroundColor Yellow

--- a/scripts/ps1/onboarding/dev_test.ps1
+++ b/scripts/ps1/onboarding/dev_test.ps1
@@ -1,0 +1,6 @@
+Write-Host "== Tests rapides backend ==" -ForegroundColor Cyan
+if (Test-Path ".venv/Scripts/Activate.ps1") { . ".venv/Scripts/Activate.ps1" }
+$env:PYTHONPATH = "backend"
+pytest -q
+if ($LASTEXITCODE -ne 0) { Write-Host "KO: tests echoues" -ForegroundColor Red; exit 1 }
+Write-Host "OK: tests passes" -ForegroundColor Green

--- a/scripts/ps1/onboarding/dev_up.ps1
+++ b/scripts/ps1/onboarding/dev_up.ps1
@@ -1,0 +1,17 @@
+param(
+[int]$Port = 8000,
+[switch]$Reload
+)
+Write-Host "== Demarrage backend dev ==" -ForegroundColor Cyan
+if (Test-Path ".venv/Scripts/Activate.ps1") { . ".venv/Scripts/Activate.ps1" }
+$env:PYTHONPATH = "backend"
+$cmd = "uvicorn backend.app.main:app --host 0.0.0.0 --port $Port" + ($(if($Reload){" --reload"} else {""}))
+Write-Host $cmd -ForegroundColor Gray
+Start-Process -FilePath python -ArgumentList "-m", "uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "$Port" -NoNewWindow
+Start-Sleep -Seconds 2
+try {
+$r = Invoke-WebRequest -UseBasicParsing "http://localhost:$Port/healthz" -TimeoutSec 5
+if ($r.StatusCode -eq 200) { Write-Host "OK: healthz 200" -ForegroundColor Green; exit 0 } else { Write-Host "KO: HTTP $($r.StatusCode)" -ForegroundColor Red; exit 3 }
+} catch {
+Write-Host "KO: backend non joignable" -ForegroundColor Red; exit 3
+}

--- a/scripts/ps1/onboarding/help.ps1
+++ b/scripts/ps1/onboarding/help.ps1
@@ -1,0 +1,9 @@
+@"
+Onboarding Dev - Commandes:
+.\scripts\ps1\onboarding\check_env.ps1 [-MinPython 3.11]
+.\scripts\ps1\onboarding\copy_env.ps1 [-Src .env.dev.example] [-Dst .env]
+.\scripts\ps1\onboarding\setup_backend.ps1
+.\scripts\ps1\onboarding\dev_up.ps1 [-Port 8000] [-Reload]
+.\scripts\ps1\onboarding\dev_down.ps1 [-Port 8000]
+.\scripts\ps1\onboarding\dev_test.ps1
+"@

--- a/scripts/ps1/onboarding/setup_backend.ps1
+++ b/scripts/ps1/onboarding/setup_backend.ps1
@@ -1,0 +1,15 @@
+param(
+[string]$Req = "requirements.txt",
+[string]$ReqDev = "requirements-dev.txt"
+)
+Write-Host "== Setup backend ==" -ForegroundColor Cyan
+if (Test-Path ".venv/Scripts/Activate.ps1") {
+Write-Host ".venv existe deja" -ForegroundColor Yellow
+} else {
+python -m venv .venv
+}
+. ".venv/Scripts/Activate.ps1"
+pip install -U pip
+if (Test-Path $Req) { pip install -r $Req } else { Write-Host "$Req introuvable" -ForegroundColor Yellow }
+if (Test-Path $ReqDev) { pip install -r $ReqDev } else { Write-Host "$ReqDev introuvable" -ForegroundColor Yellow }
+Write-Host "OK: environnements et deps installes" -ForegroundColor Green

--- a/scripts/ps1/onboarding/test_ko.ps1
+++ b/scripts/ps1/onboarding/test_ko.ps1
@@ -1,0 +1,4 @@
+# Force un KO en exigeant une version impossible
+
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ps1\onboarding\check_env.ps1 -MinPython 9.9
+if ($LASTEXITCODE -eq 0) { Write-Host "KO: check_env aurait du echouer" -ForegroundColor Red; exit 1 } else { Write-Host "OK: echec attendu check_env" -ForegroundColor Yellow }

--- a/scripts/ps1/onboarding/test_ok.ps1
+++ b/scripts/ps1/onboarding/test_ok.ps1
@@ -1,0 +1,19 @@
+# E2E: check -> env -> setup -> up -> ping -> down
+
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ps1\onboarding\check_env.ps1 -MinPython 3.11
+if ($LASTEXITCODE -ne 0) { Write-Host "KO: pre-requis" -ForegroundColor Red; exit 1 }
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ps1\onboarding\copy_env.ps1 -Src .env.dev.example -Dst .env
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ps1\onboarding\setup_backend.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ps1\onboarding\dev_up.ps1 -Port 8000
+
+# Verification via /healthz
+
+try {
+$r = Invoke-WebRequest -UseBasicParsing http://localhost:8000/healthz -TimeoutSec 5
+if ($r.StatusCode -ne 200) { throw "HTTP $($r.StatusCode)" }
+Write-Host "OK: onboarding E2E" -ForegroundColor Green
+} catch {
+Write-Host "KO: healthz" -ForegroundColor Red; exit 1
+} finally {
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ps1\onboarding\dev_down.ps1 -Port 8000 | Out-Null
+}


### PR DESCRIPTION
## Summary
- add dev onboarding scripts for PowerShell and Bash
- document quickstart and dev requirements
- provide requirements-dev.txt for test tooling

## Testing
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/ps1/onboarding/test_ok.ps1` *(fails: KO: backend non joignable)*
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/ps1/onboarding/test_ko.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68a7a695dfe08330879c93b9d75a7574