### PR TITLE
chore(ci): outillage triage CI (collecte logs, repro, rapports)

### DIFF
--- a/.ci/.gitignore
+++ b/.ci/.gitignore
@@ -1,0 +1,2 @@
+logs/
+reports/

--- a/.ci/repro_matrix.csv
+++ b/.ci/repro_matrix.csv
@@ -1,0 +1,7 @@
+job,local_cmd
+backend-tests,"PYTHONPATH=backend pytest -q"
+lint-python,"ruff check . && mypy --install-types --non-interactive backend"
+docs-build,"pip install -r requirements-docs.txt && mkdocs build --clean"
+release-dryrun,"powershell -File .\\scripts\\ps1\\release\\changelog.ps1"
+scan-secrets,"gitleaks detect --no-banner --redact --config gitleaks.toml"
+observability-tests,"PYTHONPATH=backend pytest -q backend/tests/test_metrics.py"

--- a/README-CI-TRIAGE.md
+++ b/README-CI-TRIAGE.md
@@ -1,0 +1,35 @@
+# CI Triage (Windows-first)
+
+## 1) Recuperer les runs et logs
+
+```
+$env:GITHUB_REPOSITORY="org/repo"
+.\scripts\ps1\ci\fetch_runs.ps1 -Limit 20
+# Choisir un RunId depuis .ci\logs\runs.txt
+.\scripts\ps1\ci\fetch_job_logs.ps1 -RunId 123456789
+.\scripts\ps1\ci\extract_failures.ps1
+```
+
+## 2) Repro locale (par job)
+
+```
+.\scripts\ps1\ci\repro_matrix.ps1   # genere .ci\repro_matrix.csv
+.\scripts\ps1\ci\run_local.ps1 -Job backend-tests
+```
+
+## 3) Rapport
+
+```
+.\scripts\ps1\ci\report_template.ps1 -Job backend-tests -RunId 123456789 -ErrorFile ".ci\logs\123456789\run.log.errors.txt"
+```
+
+## 4) Tests
+
+* OK: `.\\scripts\\ps1\\ci\\test_ok.ps1`
+* KO: `.\\scripts\\ps1\\ci\\test_ko.ps1`
+
+## Notes
+
+* Requiert GitHub CLI (`gh`) pour telecharger les logs. Sinon, uploder manuellement le zip des logs dans `.ci/logs/<run>/`.
+* Adapter `.ci/repro_matrix.csv` aux workflows du repo.
+* Toujours coller le bloc d'erreurs Codex/CI dans la PR de fix.

--- a/scripts/ps1/ci/extract_failures.ps1
+++ b/scripts/ps1/ci/extract_failures.ps1
@@ -1,0 +1,9 @@
+param([string]$Dir = ".ci\logs")
+if (-not (Test-Path $Dir)) { Write-Host "$Dir introuvable" -ForegroundColor Red; exit 2 }
+Get-ChildItem -Recurse -Path $Dir -Filter "*.log" | ForEach-Object {
+    $path = $_.FullName
+    $out = "$($path).errors.txt"
+    Select-String -Path $path -Pattern "ERROR|FAIL|AssertionError|Traceback|E2E FAILED|Exited with code|mypy error|ruff" -AllMatches |
+    ForEach-Object { $_.Line } | Set-Content -Encoding UTF8 $out
+    if (Test-Path $out) { Write-Host "Erreurs -> $out" -ForegroundColor Yellow }
+}

--- a/scripts/ps1/ci/fetch_job_logs.ps1
+++ b/scripts/ps1/ci/fetch_job_logs.ps1
@@ -1,0 +1,13 @@
+param(
+    [string]$Repo = $env:GITHUB_REPOSITORY,
+    [string]$RunId
+)
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { Write-Host "gh introuvable" -ForegroundColor Red; exit 2 }
+if (-not $Repo) { Write-Host "GITHUB_REPOSITORY non defini" -ForegroundColor Red; exit 3 }
+if (-not $RunId) { Write-Host "RunId requis" -ForegroundColor Red; exit 4 }
+$dest = ".ci\logs\$RunId"
+New-Item -ItemType Directory -Force -Path $dest | Out-Null
+Write-Host "== Telecharge logs run $RunId ==" -ForegroundColor Cyan
+gh run view $RunId -R $Repo --log > "$dest\run.log"
+gh run download $RunId -R $Repo -D "$dest" 2>$null
+Write-Host "OK: logs dans $dest" -ForegroundColor Green

--- a/scripts/ps1/ci/fetch_runs.ps1
+++ b/scripts/ps1/ci/fetch_runs.ps1
@@ -1,0 +1,10 @@
+param(
+    [string]$Repo = $env:GITHUB_REPOSITORY,
+    [int]$Limit = 10
+)
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { Write-Host "GitHub CLI (gh) introuvable. Installer: https://cli.github.com/" -ForegroundColor Red; exit 2 }
+if (-not $Repo) { Write-Host "GITHUB_REPOSITORY non defini (ex: org/repo)" -ForegroundColor Yellow; exit 3 }
+New-Item -ItemType Directory -Force -Path .ci\logs | Out-Null
+Write-Host "== Liste des derniers runs ($Repo) ==" -ForegroundColor Cyan
+gh run list -R $Repo -L $Limit | Tee-Object .ci\logs\runs.txt
+Write-Host "OK: .ci\logs\runs.txt" -ForegroundColor Green

--- a/scripts/ps1/ci/report_template.ps1
+++ b/scripts/ps1/ci/report_template.ps1
@@ -1,0 +1,28 @@
+param(
+    [string]$Job,
+    [string]$RunId,
+    [string]$ErrorFile
+)
+$body = @"
+
+# Rapport CI - $Job
+
+Run: $RunId
+
+Erreurs (extrait):
+$(Get-Content $ErrorFile -ErrorAction SilentlyContinue | Select-Object -First 50 -Join "`n")
+
+Repro locale:
+.\scripts\ps1\ci\run_local.ps1 -Job $Job
+
+## Hypothese:
+
+## Patch minimal:
+
+## Tests de regression:
+
+"@
+$path = ".ci\reports\$($Job)_$($RunId).md"
+New-Item -ItemType Directory -Force -Path ".ci\reports" | Out-Null
+$body | Set-Content -Encoding UTF8 $path
+Write-Host "OK: rapport -> $path" -ForegroundColor Green

--- a/scripts/ps1/ci/repro_matrix.ps1
+++ b/scripts/ps1/ci/repro_matrix.ps1
@@ -1,0 +1,12 @@
+# Matrice de repro standard (a ajuster selon workflows)
+@"
+
+job,local_cmd
+backend-tests,"PYTHONPATH=backend pytest -q"
+lint-python,"ruff check . && mypy --install-types --non-interactive backend"
+docs-build,"pip install -r requirements-docs.txt && mkdocs build --clean"
+release-dryrun,"powershell -File .\\scripts\\ps1\\release\\changelog.ps1"
+scan-secrets,"gitleaks detect --no-banner --redact --config gitleaks.toml"
+observability-tests,"PYTHONPATH=backend pytest -q backend/tests/test_metrics.py"
+"@ | Set-Content -Encoding UTF8 .ci\repro_matrix.csv
+Write-Host "OK: .ci\repro_matrix.csv" -ForegroundColor Green

--- a/scripts/ps1/ci/run_local.ps1
+++ b/scripts/ps1/ci/run_local.ps1
@@ -1,0 +1,26 @@
+param(
+    [string]$Job = "backend-tests"
+)
+$map = Import-Csv .ci\repro_matrix.csv
+$entry = $map | Where-Object { $_.job -eq $Job }
+if (-not $entry) { Write-Host "Job inconnu: $Job" -ForegroundColor Red; exit 2 }
+$cmd = $entry.local_cmd
+Write-Host "== Repro locale: $Job ==" -ForegroundColor Cyan
+Write-Host $cmd -ForegroundColor Gray
+
+# Tente via PowerShell
+
+try {
+    if ($cmd.StartsWith("PYTHONPATH=")) {
+        $parts = $cmd.Split(" ",2)
+        $envK,$rest = $parts[0],$parts[1]
+        $kv = $envK.Split("=")
+        $env:PYTHONPATH = $kv[1]
+        Invoke-Expression $rest
+    } else {
+        Invoke-Expression $cmd
+    }
+} catch {
+    Write-Host "Echec commande: $cmd" -ForegroundColor Red
+    exit 3
+}

--- a/scripts/ps1/ci/test_ko.ps1
+++ b/scripts/ps1/ci/test_ko.ps1
@@ -1,0 +1,5 @@
+# KO attendu: run sans RunId
+
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ps1\ci\fetch_job_logs.ps1 -RunId ""
+if ($LASTEXITCODE -eq 0) { Write-Host "KO: devait echouer sans RunId" -ForegroundColor Red; exit 1 }
+Write-Host "OK: echec attendu" -ForegroundColor Yellow

--- a/scripts/ps1/ci/test_ok.ps1
+++ b/scripts/ps1/ci/test_ok.ps1
@@ -1,0 +1,9 @@
+# Smoke: verifie presence gh et generation fichiers locaux
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Host "gh absent - test_ok se limitera aux fichiers locaux" -ForegroundColor Yellow
+}
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ps1\ci\repro_matrix.ps1
+if (-not (Test-Path ".ci\repro_matrix.csv")) { Write-Host "KO: repro_matrix manquante" -ForegroundColor Red; exit 1 }
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ps1\ci\run_local.ps1 -Job backend-tests
+Write-Host "OK: test_ok passe (backend-tests lance)" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- add PowerShell helpers to fetch GitHub Actions runs and job logs
- parse failures, generate local repro matrix, and scaffold CI bug reports
- include smoke tests for triage tooling

## Testing
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/ps1/ci/repro_matrix.ps1` *(fails: command not found)*
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/ps1/ci/run_local.ps1 -Job backend-tests` *(fails: command not found)*
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/ps1/ci/test_ok.ps1` *(fails: command not found)*
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/ps1/ci/test_ko.ps1` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a7a8386f808330a8ee504db498dfdb