### PR TITLE
ci: finaliser k6/obs, deps-audit SARIF, image-vuln PR informatif

### DIFF
--- a/.github/workflows/deps-audit.yml
+++ b/.github/workflows/deps-audit.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -16,8 +17,7 @@ jobs:
           python-version: "3.11"
       - name: Install pip-audit
         run: pip install pip-audit==2.7.3
-      - name: Audit runtime deps (requirements.txt)
-        id: audit
+      - name: Audit runtime deps (requirements.txt) -> SARIF
         run: |
           set -e
           if [ -f requirements.txt ]; then
@@ -30,5 +30,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: pip-audit.sarif
-      - name: Success (non-bloquant)
+      - name: Mark success
         run: echo "deps-audit completed"

--- a/.github/workflows/image-vuln.yml
+++ b/.github/workflows/image-vuln.yml
@@ -4,25 +4,35 @@ on:
     paths:
       - "Dockerfile*"
       - ".github/workflows/image-vuln.yml"
+  push:
+    branches: [ main ]
 jobs:
   trivy:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - name: Build API Image (example)
+      - name: Build minimal image (example)
         run: |
           echo "FROM python:3.11-slim" > Dockerfile.api.tmp
           docker build -t app:test -f Dockerfile.api.tmp .
-      - name: Scan with Trivy
+      - name: Scan with Trivy (PR: info only)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: app:test
+          severity: 'CRITICAL,HIGH'
           format: table
-          exit-code: '1'
-          severity: 'CRITICAL'
+          exit-code: '0'
           ignore-unfixed: true
           vuln-type: 'os,library'
-          skip-dirs: |
-            /usr/local/lib/python3.11/site-packages/pip
-          skip-files: |
-            /etc/ssl/certs/ca-certificates.crt
+      - name: Scan with Trivy (push: strict CRITICAL)
+        if: ${{ github.event_name == 'push' }}
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: app:test
+          severity: 'CRITICAL'
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'

--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -14,24 +14,23 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Install API deps (backend or mock)
+      - name: Install deps (backend or mock)
         run: |
           python -m pip install -U pip
-          pip install fastapi uvicorn
-      - name: Start API (prefer backend, fallback to mock) + wait
+          pip install fastapi uvicorn prometheus-client
+      - name: Start API (prefer backend, fallback mock) + wait
         shell: bash
         run: |
           set -euo pipefail
           export PYTHONPATH=backend:.
           # backend prioritaire
-          python - <<'PY'
+          if python - <<'PY'
 import importlib.util,sys
 sys.exit(0 if importlib.util.find_spec('backend.app.main') else 1)
 PY
-          if [ $? -eq 0 ]; then
+          then
             nohup python -m uvicorn backend.app.main:app --host 127.0.0.1 --port 8000 >/tmp/api.log 2>&1 &
           else
-            python -m pip install prometheus-client
             nohup python -m uvicorn scripts.k6.mock_api:app --host 127.0.0.1 --port 8000 >/tmp/api.log 2>&1 &
           fi
           for i in $(seq 1 30); do
@@ -41,7 +40,7 @@ PY
           done
           echo "healthz HTTP=$code"
           [ "$code" = "200" ] || (echo "healthz KO"; tail -n 200 /tmp/api.log || true; exit 2)
-      - name: Run k6 smoke (Grafana action)
+      - name: Run k6 smoke
         uses: grafana/k6-action@v0.3.1
         with:
           filename: scripts/k6/smoke.js
@@ -49,4 +48,4 @@ PY
           BASE_URL: http://127.0.0.1:8000
       - name: Tail API logs (debug on failure)
         if: failure()
-        run: tail -n +1 /tmp/api.log || true
+        run: tail -n +200 /tmp/api.log || true

--- a/.github/workflows/obs-smoke.yml
+++ b/.github/workflows/obs-smoke.yml
@@ -32,9 +32,8 @@ jobs:
           done
           echo "metrics HTTP=$code"
           [ "$code" = "200" ] || (echo "metrics KO"; tail -n 200 /tmp/api_obs.log || true; exit 2)
-      - name: Verify status-only (no content grep)
-        run: |
-          test "$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8001/metrics)" = "200"
+      - name: Verify status-only
+        run: test "$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8001/metrics)" = "200"
       - name: Tail API logs (debug on failure)
         if: failure()
-        run: tail -n +1 /tmp/api_obs.log || true
+        run: tail -n +200 /tmp/api_obs.log || true

--- a/README-CI-FIX58.md
+++ b/README-CI-FIX58.md
@@ -1,0 +1,23 @@
+# CI Fix 58 (vague finale)
+
+* k6-smoke: readiness 30s, logs /tmp/api.log en cas de KO, fallback mock.
+* obs-smoke: METRICS on, deps explicites, check 200, logs.
+* deps-audit: rapport SARIF, job non-bloquant.
+* image-vuln: PR informatif (exit 0), push strict (CRITICAL).
+
+Repro rapide:
+
+* k6 (runner): workflow k6-smoke.
+* obs local: `.\\scripts\\ps1\\ci\\repro_obs_local.ps1` (ou `uvicorn backend.app.main:app …` puis `curl :8001/metrics`).
+* deps-audit: `pip-audit -r requirements.txt -l --format sarif -o pip-audit.sarif || true`.
+* image-vuln: `docker build` puis trivy (non requis localement si indispo).
+
+Contraintes:
+ASCII, Windows-first. Aucun secret. CI < 5 min/job.
+
+Tests (PowerShell + sorties attendues):
+
+1. Obs local: script -> “OK: /metrics 200”.
+2. k6 CI: healthz HTTP=200 avant exécution.
+3. deps-audit CI: job success + SARIF upload.
+4. image-vuln CI: PR passe (exit 0), push main strict.

--- a/scripts/ps1/ci/repro_obs_local.ps1
+++ b/scripts/ps1/ci/repro_obs_local.ps1
@@ -2,8 +2,8 @@ $env:PYTHONPATH = "backend"
 $env:METRICS_ENABLED = "1"
 $env:METRICS_PATH = "/metrics"
 Start-Process -FilePath python -ArgumentList "-m","uvicorn","backend.app.main:app","--host","127.0.0.1","--port","8001" -NoNewWindow
-Start-Sleep -Seconds 2
+Start-Sleep -Seconds 3
 try {
-    $r = Invoke-WebRequest -UseBasicParsing http://127.0.0.1:8001/metrics -TimeoutSec 5
+    $r = Invoke-WebRequest -UseBasicParsing http://127.0.0.1:8001/metrics -TimeoutSec 10
     if ($r.StatusCode -eq 200) { Write-Host "OK: /metrics 200" -ForegroundColor Green } else { exit 2 }
 } catch { Write-Host "KO: /metrics" -ForegroundColor Red; exit 2 }


### PR DESCRIPTION
## Summary
- ensure k6 smoke uses readiness checks and logs, fallback mock
- enable metrics smoke test with explicit deps and status-only check
- emit SARIF for deps audit without failing PRs
- make Trivy informational on PRs and strict on main

## Testing
- `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8001/metrics` → 200
- `curl -s -o /du`

------
https://chatgpt.com/codex/tasks/task_e_68a7bcf3884483309e399e6d73fe7e28