### PR TITLE
ci: mypy stubs & install-types, deps-audit SARIF guard, obs-smoke installs requirements

### DIFF
--- a/.github/workflows/deps-audit.yml
+++ b/.github/workflows/deps-audit.yml
@@ -25,6 +25,8 @@ jobs:
           else
             echo "{}" > pip-audit.sarif
           fi
+          # File de secours si pour une raison quelconque le fichier n'existe pas
+          [ -f pip-audit.sarif ] || echo "{}" > pip-audit.sarif
       - name: Upload SARIF (best-effort)
         if: always()
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -11,11 +11,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Install linters
+      - name: Install linters + stubs manquants
         run: |
           python -m pip install -U pip
-          pip install ruff==0.6.4 mypy==1.10.0
-      - name: Ruff (E/F/I seulement, backend)
+          pip install ruff==0.6.4 mypy==1.10.0 types-redis
+      - name: Ruff (backend)
         run: ruff check backend --select E,F,I --ignore E203,E266,E501
-      - name: MyPy (app+cli)
-        run: mypy backend/app backend/cli
+      - name: MyPy (app+cli) avec install auto des stubs
+        run: mypy backend/app backend/cli --install-types --non-interactive

--- a/.github/workflows/obs-smoke.yml
+++ b/.github/workflows/obs-smoke.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "backend/**"
+      - "requirements*.txt"
       - ".github/workflows/obs-smoke.yml"
 jobs:
   obs:
@@ -13,10 +14,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Install deps (metrics)
+      - name: Install deps (requirements si dispo, sinon secours)
+        shell: bash
         run: |
+          set -euo pipefail
           python -m pip install -U pip
-          pip install fastapi uvicorn prometheus-client prometheus-fastapi-instrumentator
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          else
+            pip install fastapi uvicorn sqlalchemy prometheus-client prometheus-fastapi-instrumentator
+          fi
       - name: Start API with METRICS + wait
         shell: bash
         run: |

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 from sqlalchemy import text
 from starlette.responses import JSONResponse
+from typing import cast
 
 from .config import settings
 from .db import engine
@@ -56,8 +57,9 @@ def _redis_ready() -> bool:
         import redis
 
         url = urlparse(settings.REDIS_URL)
+        host = cast(str, url.hostname)
         client = redis.Redis(
-            host=url.hostname, port=url.port or 6379, db=int((url.path or "/0").lstrip("/"))
+            host=host, port=url.port or 6379, db=int((url.path or "/0").lstrip("/"))
         )
         client.ping()
         return True

--- a/backend/tests/test_redis_ready_url.py
+++ b/backend/tests/test_redis_ready_url.py
@@ -1,0 +1,7 @@
+from app import api
+from app.config import settings
+
+def test_redis_ready_bad_url(monkeypatch):
+    monkeypatch.setattr(settings, "READINESS_REQUIRE_REDIS", True)
+    monkeypatch.setattr(settings, "REDIS_URL", "redis:///0")
+    assert api._redis_ready() is False

--- a/scripts/ps1/ci/repro_deps_audit_local.ps1
+++ b/scripts/ps1/ci/repro_deps_audit_local.ps1
@@ -1,0 +1,9 @@
+param([string]$Req = "requirements.txt")
+pip install pip-audit==2.7.3 | Out-Null
+if (Test-Path $Req) {
+    pip-audit -r $Req -l --progress-spinner=off --strict=false --format sarif -o pip-audit.sarif 2>$null
+} else {
+    "{}" | Set-Content -Encoding UTF8 pip-audit.sarif
+}
+if (-not (Test-Path "pip-audit.sarif")) { "{}" | Set-Content -Encoding UTF8 pip-audit.sarif }
+Write-Host "OK: pip-audit.sarif present" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- install redis stubs and auto-install missing ones for mypy
- always write a pip-audit.sarif file so the upload step never fails
- obs-smoke installs requirements when present otherwise uses fallback deps
- cover redis readiness URL parsing

## Testing
- `ruff check backend --select E,F,I --ignore E203,E266,E501`
- `mypy backend/app backend/cli --install-types --non-interactive`
- `PYTHONPATH=backend pytest backend/tests/test_redis_ready_url.py`
- `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8001/metrics`
- `pwsh scripts/ps1/ci/repro_deps_audit_local.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a84397a2288330b4d891e6ad7651cb