### PR TITLE
fix(ci): storybook cache lockfile (frontend)

### DIFF
--- a/.github/workflows/frontend-storybook.yml
+++ b/.github/workflows/frontend-storybook.yml
@@ -1,0 +1,34 @@
+name: frontend-storybook
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-storybook.yml'
+permissions:
+  contents: read
+jobs:
+  storybook:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node 20 + npm cache (frontend lockfile)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'frontend/package-lock.json'
+      - name: Install deps (frontend)
+        run: npm ci --no-audit --no-fund
+      - name: Build storybook
+        run: npm run build:storybook
+      - name: Smoke serve + probe (6006)
+        run: |
+          npx http-server ./storybook-static -p 6006 -s &
+          sleep 2
+          curl -fsS http://127.0.0.1:6006 > /dev/null
+      - name: Bundle budget (size-limit)
+        run: npm run size:check

--- a/PS1/repro_storybook_ci_lock.ps1
+++ b/PS1/repro_storybook_ci_lock.ps1
@@ -1,0 +1,33 @@
+# repro_storybook_ci_lock.ps1
+param(
+  [string]$FrontendPath = "frontend"
+)
+
+$ErrorActionPreference = "Stop"
+Write-Host "== Repro Storybook CI lockfile =="
+
+if (-not (Test-Path $FrontendPath)) {
+  Write-Error "Path not found: $FrontendPath"
+}
+
+$lock = Join-Path $FrontendPath "package-lock.json"
+if (-not (Test-Path $lock)) {
+  Write-Error "Missing lockfile: $lock"
+}
+
+Push-Location $FrontendPath
+try {
+  node -v
+  npm -v
+  Write-Host "Running: npm ci --no-audit --no-fund"
+  npm ci --no-audit --no-fund
+  Write-Host "Running: npm run build:storybook"
+  npm run build:storybook
+  if (-not (Test-Path "storybook-static")) {
+    Write-Error "storybook-static not found after build."
+  }
+  Write-Host "OK: build storybook done."
+}
+finally {
+  Pop-Location
+}

--- a/docs/ci/frontend-storybook.md
+++ b/docs/ci/frontend-storybook.md
@@ -1,0 +1,13 @@
+# CI front: Storybook
+
+- Contexte: monorepo, lockfile sous `frontend/package-lock.json`.
+- Action: `actions/setup-node@v4` avec `cache: npm` DOIT pointer `cache-dependency-path: frontend/package-lock.json`.
+- Jobs: build storybook, probe HTTP, bundle budget (size-limit).
+
+## Commandes locales
+
+pwsh -NoLogo -NoProfile -File PS1/repro_storybook_ci_lock.ps1
+
+## Notes
+- Ne pas deplacer le lockfile a la racine sans convertir le repo en workspace npm complet.
+- Zero secret dans workflows.


### PR DESCRIPTION
## Summary
- point Storybook workflow npm cache to frontend/package-lock.json
- document Storybook CI setup
- add Windows repro script for Storybook build

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/repro_storybook_ci_lock.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68b4050c3ac88330b1f8a3f3989170c7