### PR TITLE
fix(ci): storybook cache (monorepo) + remove unused mypy ignores

### DIFF
--- a/.github/workflows/frontend-storybook.yml
+++ b/.github/workflows/frontend-storybook.yml
@@ -15,13 +15,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Use Node 20 + npm cache (frontend lockfile)
+      - name: Use Node 20
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: 'frontend/package-lock.json'
+          # IMPORTANT: on NE pas utiliser cache: npm ici (bug path en monorepo)
+      - name: Preflight lockfile
+        run: |
+          test -f package-lock.json || (echo "ERREUR: frontend/package-lock.json introuvable." && exit 2)
+      - name: Cache npm (frontend lockfile -> ~/.npm)
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
       - name: Install deps (frontend)
+        env:
+          NPM_CONFIG_CACHE: ~/.npm
         run: npm ci --no-audit --no-fund
       - name: Build storybook
         run: npm run build:storybook

--- a/PS1/repro_storybook_ci_cache.ps1
+++ b/PS1/repro_storybook_ci_cache.ps1
@@ -1,0 +1,41 @@
+# Repro locale Windows du pipeline Storybook avec cache npm (~/.npm)
+param(
+  [string]$FrontendPath = "frontend"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+Write-Host "== Repro Storybook CI (cache npm) =="
+
+if (-not (Test-Path $FrontendPath)) {
+  Write-Error "Dossier introuvable: $FrontendPath"
+}
+
+$lock = Join-Path $FrontendPath "package-lock.json"
+if (-not (Test-Path $lock)) {
+  Write-Error "Lockfile manquant: $lock"
+}
+
+$npmCache = Join-Path $HOME ".npm"
+if (-not (Test-Path $npmCache)) {
+  New-Item -ItemType Directory -Path $npmCache | Out-Null
+}
+
+Push-Location $FrontendPath
+try {
+  node -v
+  npm -v
+  $env:NPM_CONFIG_CACHE = $npmCache
+  Write-Host "npm ci..."
+  npm ci --no-audit --no-fund
+  Write-Host "build storybook..."
+  npm run build:storybook
+  if (-not (Test-Path "storybook-static")) {
+    Write-Error "storybook-static manquant apres build."
+  }
+  Write-Host "OK"
+} finally {
+  Pop-Location
+}
+

--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ Pages:
 
 Tests: Vitest (helpers d'API et cache).
 
+## CI Frontend
+- Lints, typecheck, tests, build.
+- Storybook: cache npm via `actions/cache` (chemin `~/.npm`) avec clé derivee de `frontend/package-lock.json`. Ne pas utiliser `cache: npm` de `setup-node` en monorepo.
+
 ## Docker Compose (Postgres)
 
 ### Postgres (local via Docker Compose)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,12 +1,12 @@
 import os
 from functools import lru_cache
-from typing import List
+from typing import Any, List, cast
 
 try:
     from dotenv import dotenv_values, load_dotenv
 except Exception:  # pragma: no cover
-    load_dotenv = None  # type: ignore[assignment]
-    dotenv_values = None  # type: ignore[assignment]
+    load_dotenv = cast(Any, None)
+    dotenv_values = cast(Any, None)
 
 
 def _split_csv(value: str) -> List[str]:

--- a/docs/ci/frontend-storybook.md
+++ b/docs/ci/frontend-storybook.md
@@ -1,13 +1,31 @@
-# CI front: Storybook
+# CI Frontend: Storybook (monorepo)
 
-- Contexte: monorepo, lockfile sous `frontend/package-lock.json`.
-- Action: `actions/setup-node@v4` avec `cache: npm` DOIT pointer `cache-dependency-path: frontend/package-lock.json`.
-- Jobs: build storybook, probe HTTP, bundle budget (size-limit).
+## Contrainte
+Le lockfile est sous `frontend/package-lock.json`.
+Le cache integre de `actions/setup-node@v4` (`cache: npm`) peut echouer avec:
+> Some specified paths were not resolved, unable to cache dependencies.
 
-## Commandes locales
+## Solution robuste
+- Utiliser `actions/cache@v4` sur `~/.npm` avec une cle basee sur `frontend/package-lock.json`.
+- Forcer `NPM_CONFIG_CACHE=~/.npm` pendant `npm ci`.
 
-pwsh -NoLogo -NoProfile -File PS1/repro_storybook_ci_lock.ps1
+Extrait:
 
-## Notes
-- Ne pas deplacer le lockfile a la racine sans convertir le repo en workspace npm complet.
-- Zero secret dans workflows.
+```yaml
+- uses: actions/setup-node@v4
+  with:
+    node-version: '20'
+
+- uses: actions/cache@v4
+  with:
+    path: ~/.npm
+    key: ${{ runner.os }}-npm-${{ hashFiles('frontend/package-lock.json') }}
+
+- run: npm ci --no-audit --no-fund
+  env:
+    NPM_CONFIG_CACHE: ~/.npm
+```
+
+Smoke
+Servir storybook-static et curl sur 6006 pour un 200.
+


### PR DESCRIPTION
## Summary
- robust npm caching for Storybook via actions/cache keyed by frontend/package-lock.json
- document Storybook cache approach and provide Windows repro script
- drop superfluous mypy ignores and type-safe dotenv fallback

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/repro_storybook_ci_cache.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `backend/.venv/Scripts/python -m mypy --config-file backend/mypy.ini backend` *(fails: No such file or directory)*
- `python -m mypy backend/app/core/config.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4247e5f148330a81cfd3b3a6a1e7b